### PR TITLE
Refactor sun.py to Remove User-Specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Most of the code and setup stolen from: [Instructables](https://www.instructable
 ## Install
 There's an [install.sh](install.sh) script that does (almost) everything at once. If in doubt, see the [install guide](docs/INSTALL.md)
 
+Once you've performed an installation or if you're pulling down the latest version of code, use the `check.sh` script to ensure all of
+the requisite changes needed for the version of code you're using are in place. For example, in one refactor, the `sun.py` script was
+updated to rely on `/home/pi/.noaa.conf` having vars declared for `LAT`, `LON`, and `TZ_OFFSET` - if any of these are missing, the check
+script will fail and report what needs to occur to fix this.
+
 ## Post config
 * [Setup Twitter auto posting feature](docs/INSTALL.md#set-your-twitter-credentials)
 

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+BLUE=$(tput setaf 4)
+BOLD=$(tput bold)
+RESET=$(tput sgr0)
+
+. "$HOME/.noaa.conf"
+
+die() {
+    >&2 echo "${RED}error: $1${RESET}" && exit 1
+}
+
+log_running() {
+    echo " ${YELLOW}*${RESET} $1"
+}
+
+
+log_done() {
+    echo "    ${GREEN}✓${RESET} $1"
+}
+
+log_error() {
+    echo "    ${RED}error: $1${RESET}"
+}
+
+success() {
+    echo "${GREEN}$1${RESET}"
+}
+
+### Run as a normal user
+if [ $EUID -eq 0 ]; then
+    die "This script shouldn't be run as root."
+fi
+
+# check to ensure TZ_OFFSET is added to noaa.conf
+# which is needed since updating sun.py to be generic
+# and use bash environment vars
+log_running "Checking for TZ_OFFSET env var..."
+if [[ -v TZ_OFFSET ]]; then
+  log_done "TZ_OFFSET in place - all set"
+else
+  log_error "TZ_OFFSET is missing from /home/pi/.noaa.conf - please add."
+fi
+
+echo "All checks complete - please see above for details!"

--- a/install.sh
+++ b/install.sh
@@ -298,10 +298,9 @@ read -rp "Enter your longitude (West values are negative): "
 read -rp "Enter your timezone offset (ex: -3 for Argentina time): "
     tzoffset=$REPLY
 
-sed -i -e "s/change_latitude/${lat}/g;s/change_longitude/${lon}/g" "$HOME/.noaa.conf"
+sed -i -e "s/change_latitude/${lat}/g;s/change_longitude/${lon}/g;s/change_tz_offset/${tzoffset}/g" "$HOME/.noaa.conf"
 sed -i -e "s/change_latitude/${lat}/g;s/change_longitude/${lon}/g" "$HOME/.wxtoimgrc"
 sed -i -e "s/change_latitude/${lat}/g;s/change_longitude/$(echo  "$lon * -1" | bc)/g" "$HOME/.predict/predict.qth"
-sed -i -e "s/change_latitude/${lat}/g;s/change_longitude/${lon}/g;s/change_tz/$(echo  "$tzoffset * -1" | bc)/g" "sun.py"
 
 success "Install done! Double check your $HOME/.noaa.conf settings"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy==1.18.1
 Pillow==7.1.2
 tweepy==3.8.0
 urllib3==1.25.8
+envbash==1.2.0

--- a/sun.py
+++ b/sun.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
+import envbash
 import ephem
 import time
 import sys
-timezone = change_tz + time.localtime().tm_isdst
+import os
+from envbash import load_envbash
+
+# load bash environment vars
+load_envbash('/home/pi/.noaa.conf')
+tz_offset = int(os.environ['TZ_OFFSET'])
+lat = float(os.environ['LAT'])
+lon = float(os.environ['LON'])
+
+timezone = (tz_offset * -1) + time.localtime().tm_isdst
 date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(int(sys.argv[1])-(timezone*60*60)))
 
 obs=ephem.Observer()
-obs.lat='change_latitude'
-obs.long='change_longitude'
+obs.lat = lat
+obs.long = lon
 obs.date = date
 
 sun = ephem.Sun(obs)

--- a/templates/noaa.conf
+++ b/templates/noaa.conf
@@ -13,3 +13,4 @@ DELETE_AUDIO="true"
 FLIP_METEOR_IMG="true"
 GAIN=50
 SCHEDULE_ISS="false"
+TZ_OFFSET=change_tz_offset


### PR DESCRIPTION
Update to use parameters in the sun.py script rather than hard-coded
user-specific settings. This commit includes updates to the README and a
check.sh script that will perform a "health check" for the user
environment to catch users who updated their repo but haven't yet placed
TZ_OFFSET into their noaa.conf, for example.