### PR TITLE
Condense Configs and Add Map Options for Crosshair and Coloring

### DIFF
--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -1,4 +1,3 @@
-# framework configs
 NOAA_HOME={{ noaa_home }}
 DB_FILE={{ db_file }}
 WEB_HOME={{ web_home }}
@@ -6,26 +5,20 @@ IMAGE_OUTPUT={{ images_output }}
 NOAA_AUDIO_OUTPUT={{ audio_output }}/noaa
 METEOR_AUDIO_OUTPUT={{ audio_output }}/meteor
 RAMFS_AUDIO={{ ramfs_path }}
-
-# base station configs
 LAT={{ latitude }}
 LON={{ longitude }}
-
-# whether to schedule specific objects
-SCHEDULE_ISS="{% if schedule_iss|string == 'True' %}true{% else %}false{% endif %}"
-SCHEDULE_NOAA="{% if schedule_noaa|string == 'True' %}true{% else %}false{% endif %}"
-SCHEDULE_METEOR="{% if schedule_meteor|string == 'True' %}true{% else %}false{% endif %}"
-
-# thresholds for captures
+SCHEDULE_ISS={{ schedule_iss|lower }}
+SCHEDULE_NOAA={{ schedule_noaa|lower }}
+SCHEDULE_METEOR={{ schedule_meteor|lower }}
 SAT_MIN_ELEV={{ sat_min_elevation }}
 SUN_MIN_ELEV={{ sun_min_elevation }}
-
-# system configs, processing configs, and sdr tuning
-DELETE_AUDIO="{% if delete_audio|string == 'True' %}true{% else %}false{% endif %}"
-BIAS_TEE="{% if enable_bias_tee|string == 'True' %}-T{% endif %}"
-FLIP_METEOR_IMG="true"
-GAIN=50
-
-# language and debugging
+DELETE_AUDIO={{ delete_audio|lower }}
+BIAS_TEE={{ enable_bias_tee|lower }}
+FLIP_METEOR_IMG={{ flip_meteor_image|lower }}
+GAIN={{ receiver_gain }}
 TZ_OFFSET={{ timezone_offset }}
-LOG_LEVEL=DEBUG
+LOG_LEVEL={{ log_level }}
+NOAA_MAP_CROSSHAIR_ENABLE={{ noaa_map_crosshair_enable|lower }}
+NOAA_MAP_CROSSHAIR_COLOR={{ noaa_map_crosshair_color }}
+NOAA_MAP_GRID_DEGREES={{ noaa_map_grid_degrees }}
+NOAA_MAP_GRID_COLOR={{ noaa_map_grid_color }}

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -8,22 +8,49 @@ longitude: -74.005974
 # time zone offset from UTC (for example, '-5' for US Eastern)
 timezone_offset: -5
 
-# whether to enable bias tee (power LNA or upstream devices from SDR)
-enable_bias_tee: True
+# receiver settings
+#   enable_bias_tee - driving power to LNA, for example
+#   gain - receiver gain
+enable_bias_tee: false
+receiver_gain: 50
 
 # whether to schedule specific orbiting objects for capture
-schedule_iss: False
-schedule_noaa: True
-schedule_meteor: True
+schedule_iss: false
+schedule_noaa: true
+schedule_meteor: true
 
 # whether audio files should be deleted after images are created
-delete_audio: False
+delete_audio: false
 
 # thresholds for scheduling captures - enables avoiding an attempt
 # to capture imagery if objects are lower than these degree elevation thresholds
 sat_min_elevation: 30
-meteor_min_elevation: 30
 sun_min_elevation: 10
+
+# noaa map configurations
+# http://usradioguy.com/wp-content/uploads/2020/05/wxtoimgcommand-line.pdf
+#
+# note - colors are in format 0xRRGGBB (only applicable when the
+#        feature is enabled), where:
+#   RR: Red hex value
+#   GG: Green hex value
+#   BB: Blue hex value
+# Colors can alternatively be specified as one of the following:
+#   black, white, gray, light-gray, dark-gray, red, pink dark-red,
+#   light-red, # green, light-green, dark-green, black-green, blue,
+#   light-blue, dark-blue, black-blue, yellow, light-yellow, dark-yellow,
+#   magenta, light-magenta, dark-magenta, cyan, light-cyan, dark-cyan,
+#   orange, dark-orange, purple, lavender, violet, navy, turquoise,
+#   aquamarine, chartreuse, gold, beige, tan, brown, and maroon
+#
+#   noaa_map_crosshair_enable - whether to place a crosshairs on the base station location
+#   noaa_map_crosshair_color - color of base station crosshair
+#   noaa_map_grid_degrees - latitude/longitude lines drawn every grid degrees (default 10.0, 0.0 to disable)
+#   noaa_map_grid_color - color of gridlines for latitude/longitude
+noaa_map_crosshair_enable: false
+noaa_map_crosshair_color: "0xffff00"
+noaa_map_grid_degrees: 10.0
+noaa_map_grid_color: "0xff0000"
 
 # locale settings for timezone and language
 #   timezone: see https://www.php.net/manual/en/timezones.php
@@ -34,4 +61,7 @@ lang_setting: en
 
 # port to run the webpanel on
 web_port: 80
+
+# log level for output from scripts
+log_level: DEBUG
 ...

--- a/scripts/receive_noaa.sh
+++ b/scripts/receive_noaa.sh
@@ -47,8 +47,20 @@ log "Bulding pass map" "INFO"
 # going over the start time by a few seconds while still being within the pass timing causes wxmap
 # to track *back* to the start of the pass
 epoch_adjusted=$(($PASS_START + 10))
-/usr/local/bin/wxmap -T "${1}" -H "${4}" -p 0 -l 0 -o "${epoch_adjusted}" "${NOAA_HOME}/tmp/map/${3}-map.png"
 
+# calculate any extra map options such as crosshair for base station, coloring, etc.
+extra_map_opts=""
+if [ "${NOAA_MAP_CROSSHAIR_ENABLE}" == "true" ]; then
+  extra_map_opts="${extra_map_opts} -l 1 -c l:${NOAA_MAP_CROSSHAIR_COLOR}"
+fi
+if [ "${NOAA_MAP_GRID_DEGREES}" != "0.0" ]; then
+  extra_map_opts="${extra_map_opts} -g ${NOAA_MAP_GRID_DEGREES} -c g:${NOAA_MAP_GRID_COLOR}"
+fi
+
+# build overlay map
+/usr/local/bin/wxmap -T "${1}" -H "${4}" -p 0 ${extra_map_opts} -o "${epoch_adjusted}" "${NOAA_HOME}/tmp/map/${3}-map.png"
+
+# build images based on enhancements defined
 for i in $ENHANCEMENTS; do
   log "Decoding image" "INFO"
   /usr/local/bin/wxtoimg -o -m "${NOAA_HOME}/tmp/map/${3}-map.png" -e "$i" "${RAMFS_AUDIO}/${3}.wav" "${IMAGE_OUTPUT}/${3}-$i.jpg"


### PR DESCRIPTION
Add ability to specify placing a crosshair on the base station location on the overlay map for NOAA captures, coloring for the crosshair, adjusting the lat/lon lines (or disabling), and color for lines. Also condense home directory environment file since the explanations for parameters are now in the settings.yml file.