### PR TITLE
Add Satvis Visualization Option

### DIFF
--- a/ansible/roles/webserver/templates/Config.php.j2
+++ b/ansible/roles/webserver/templates/Config.php.j2
@@ -20,6 +20,9 @@ class Config {
 
   # location of thumbnails
   const THUMB_PATH = '{{ images_output }}/thumb';
+
+  # whether to enable satvis visualization
+  const ENABLE_SATVIS = '{{ enable_satvis|lower }}';
 }
 
 ?>

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -64,4 +64,10 @@ web_port: 80
 
 # log level for output from scripts
 log_level: DEBUG
+
+# whether to enable the satvis visualization for satellite tracking
+# in the passes view - note that this iframe-driven visualization is
+# by default disabled on "extra-small" devices such as phones due to
+# the processing and space requirements
+enable_satvis: true
 ...

--- a/webpanel/App/Views/Passes/index.html
+++ b/webpanel/App/Views/Passes/index.html
@@ -4,6 +4,14 @@
   <link rel="stylesheet" type="text/css" href="/assets/css/pass_list.css">
 {% endblock %}
 
+{% block pre_body %}
+  {% if constant('Config\\Config::ENABLE_SATVIS') == 'true' %}
+    <div id="satvis" class="d-none d-sm-block">
+      <iframe name="satvis" src="https://satvis.space/?elements=Point,Label,Orbit%20track,Sensor%20cone&layers=OfflineHighres&gs=50.8515,-0.1446&tags=Weather"></iframe>
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block body %}
   <table class="table table-bordered table-sm table-striped" id="passes">
     <thead class="thead-dark">

--- a/webpanel/App/Views/base.html
+++ b/webpanel/App/Views/base.html
@@ -38,6 +38,9 @@
     </header>
 
     <div class="container">
+      {% block pre_body %}
+      {% endblock %}
+
       {% block body %}
       {% endblock %}
     </div>

--- a/webpanel/public/assets/css/pass_list.css
+++ b/webpanel/public/assets/css/pass_list.css
@@ -1,3 +1,14 @@
+div#satvis {
+  width: 100%;
+  height: 400px;
+}
+
+div#satvis iframe {
+  border: 0;
+  width: 100%;
+  height: 100%;
+}
+
 table#passes tr.inactive {
   color: lightgray;
 }


### PR DESCRIPTION
Add an option to enable the satvis global satellite tracking animation in the pass list page, and have it disabled by default for extra-small devices (phones).