### PR TITLE
escape brackets as well (For ISS(ZARYA) )

### DIFF
--- a/scripts/schedule_captures.sh
+++ b/scripts/schedule_captures.sh
@@ -40,11 +40,11 @@ while [ "$(date --date="@${end_epoch_time}" +%D)" = "$(date +%D)" ]; do
   file_date_ext=$(date --date="TZ=\"UTC\" ${start_datetime}" +%Y%m%d-%H%M%S)
 
   if [ "${max_elev}" -gt "${SAT_MIN_ELEV}" ]; then
-    safe_obj_name=$(echo "${OBJ_NAME}" | sed "s/ //g")
+    printf -v safe_obj_name "%q" $(echo "${OBJ_NAME}" | sed "s/ /-/g")
     log "Scheduling capture for: ${safe_obj_name} ${file_date_ext} ${max_elev}" "INFO"
-    echo "${NOAA_HOME}/scripts/${RECEIVE_SCRIPT} \"${OBJ_NAME}\" $FREQ ${safe_obj_name}${file_date_ext} "${TLE_FILE}" \
+    echo "${NOAA_HOME}/scripts/${RECEIVE_SCRIPT} \"${OBJ_NAME}\" $FREQ ${safe_obj_name}-${file_date_ext} "${TLE_FILE}" \
 ${start_epoch_time} ${timer} ${max_elev}" | at "$(date --date="TZ=\"UTC\" ${start_datetime}" +"%H:%M %D")"
-    sqlite3 $DB_FILE "insert or replace into predict_passes (sat_name,pass_start,pass_end,max_elev,is_active) values (\"$safe_obj_name\",$start_epoch_time,$end_epoch_time,$max_elev,1);"
+    sqlite3 $DB_FILE "insert or replace into predict_passes (sat_name,pass_start,pass_end,max_elev,is_active) values (\"${OBJ_NAME}\",$start_epoch_time,$end_epoch_time,$max_elev,1);"
   fi
   next_predict=$(expr "${end_epoch_time}" + 60)
   predict_start=$(/usr/bin/predict -t "${TLE_FILE}" -p "${OBJ_NAME}" "${next_predict}" | head -1)


### PR DESCRIPTION
Hi, scheduled ISS passes fail because the `safe_filename` contains unescaped braces.

```bash
/home/pi/raspberry-noaa-v2/scripts/receive_iss.sh "ISS (ZARYA)" 145.8000 ISS(ZARYA)20210209-154555 /home/pi/raspberry-noaa-v2/tmp/orbit.tle 1612881955 696 37
-bash: syntax error near unexpected token `('
```

My Fix changes the "space" escaping to a `-` as well as the auto-escaping of braces and other stuff (Would also escape spaces).

Notice that additionally, I added a `-` to `${safe_obj_name}-${file_date_ext}` so that the file name pattern matches the expectations of noaa-apt.
Also, to circumvent doubly escaped strings in the database, the original obj name is inserted.


Passing `""` around `"${safe_obj_name}-${file_date_ext}"` would probably work, too, but then all other scripts would need to be space-safe as well.