### PR TITLE
Fix NTP Install

### DIFF
--- a/ansible/roles/common/files/ntp.conf
+++ b/ansible/roles/common/files/ntp.conf
@@ -1,0 +1,64 @@
+####### MANAGED BY ANSIBLE! ##########
+# Please do not make changes by hand #
+######################################
+
+# /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
+
+driftfile /var/lib/ntp/ntp.drift
+
+# Leap seconds definition provided by tzdata
+leapfile /usr/share/zoneinfo/leap-seconds.list
+
+# Enable this if you want statistics to be logged.
+#statsdir /var/log/ntpstats/
+
+statistics loopstats peerstats clockstats
+filegen loopstats file loopstats type day enable
+filegen peerstats file peerstats type day enable
+filegen clockstats file clockstats type day enable
+
+
+# You do need to talk to an NTP server or two (or three).
+#server ntp.your-provider.example
+
+# pool.ntp.org maps to about 1000 low-stratum NTP servers.  Your server will
+# pick a different set every time it starts up.  Please consider joining the
+# pool: <http://www.pool.ntp.org/join.html>
+pool 0.debian.pool.ntp.org iburst
+pool 1.debian.pool.ntp.org iburst
+pool 2.debian.pool.ntp.org iburst
+pool 3.debian.pool.ntp.org iburst
+
+
+# Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
+# details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>
+# might also be helpful.
+#
+# Note that "restrict" applies to both servers and clients, so a configuration
+# that might be intended to block requests from certain clients could also end
+# up blocking replies from your own upstream servers.
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict -4 default kod notrap nomodify nopeer noquery limited
+restrict -6 default kod notrap nomodify nopeer noquery limited
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1
+
+# Needed for adding pool entries
+restrict source notrap nomodify noquery
+
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+
+# If you want to provide time to your local subnet, change the next line.
+# (Again, the address is an example only.)
+#broadcast 192.168.123.255
+
+# If you want to listen to time broadcasts on your local subnet, de-comment the
+# next lines.  Please do this only if you trust everybody on the network!
+#disable auth
+#broadcastclient

--- a/ansible/roles/common/files/rtlsdr.conf
+++ b/ansible/roles/common/files/rtlsdr.conf
@@ -1,3 +1,7 @@
+####### MANAGED BY ANSIBLE! ##########
+# Please do not make changes by hand #
+######################################
+
 blacklist dvb_usb_rtl28xxu
 blacklist rtl2832
 blacklist rtl2830

--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart ntp
+  become: yes
+  service:
+    name: ntp
+    state: restarted
+...

--- a/ansible/roles/common/tasks/dependencies.yml
+++ b/ansible/roles/common/tasks/dependencies.yml
@@ -18,7 +18,6 @@
       - libusb-1.0-0-dev
       - libxft-dev
       - libxft2
-      - ntp
       - predict
       - python3-pip
       - python-setuptools

--- a/ansible/roles/common/tasks/dependencies.yml
+++ b/ansible/roles/common/tasks/dependencies.yml
@@ -3,6 +3,7 @@
   become: yes
   apt:
     update_cache: yes
+    state: present
     name:
       - at
       - bc
@@ -28,12 +29,16 @@
 - name: install dependencies (stretch only)
   become: yes
   apt:
+    update_cache: no
+    state: present
     name: libgfortran-5-dev
   when: raspbian_version.stdout == 'stretch'
 
 - name: install dependencies (non-stretch)
   become: yes
   apt:
+    update_cache: no
+    state: present
     name: libgfortran5
   when: raspbian_version.stdout != 'stretch'
 

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -5,6 +5,9 @@
 # dependent packages and libs to be installed
 - include: dependencies.yml
 
+# ntp configurations
+- include: ntp.yml
+
 # core software modules
 - include: sdr.yml
 

--- a/ansible/roles/common/tasks/ntp.yml
+++ b/ansible/roles/common/tasks/ntp.yml
@@ -1,0 +1,25 @@
+---
+- name: install ntp
+  become: yes
+  apt:
+    update_cache: no
+    state: present
+    name: ntp
+
+- name: disable systemd-timesyncd
+  become: yes
+  service:
+    name: systemd-timesyncd
+    state: stopped
+    enabled: no
+
+- name: ntp config file
+  become: yes
+  copy:
+    src: ntp.conf
+    dest: /etc/ntp.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart ntp
+...

--- a/ansible/roles/webserver/tasks/main.yml
+++ b/ansible/roles/webserver/tasks/main.yml
@@ -18,12 +18,14 @@
   become: yes
   apt:
     update_cache: no
+    state: present
     name: nginx
 
 - name: install php
   become: yes
   apt:
     update_cache: no
+    state: present
     name:
       - php7.2-fpm
       - php7.2-mbstring
@@ -33,6 +35,7 @@
   become: yes
   apt:
     update_cache: no
+    state: present
     name: composer
 
 - name: add pi user to www-data group


### PR DESCRIPTION
Fix the NTP install by having it not only install but add a configuration file and disable systemd-timesyncd to ensure there are no conflicts that can cause "jumping" clocks on devices.