### PR TITLE
Fix Python (Ansible) Dependency

### DIFF
--- a/ansible/roles/common/tasks/dependencies.yml
+++ b/ansible/roles/common/tasks/dependencies.yml
@@ -40,8 +40,4 @@
     state: present
     name: libgfortran5
   when: raspbian_version.stdout != 'stretch'
-
-- name: python packages using pip3
-  become: yes
-  command: "python3 -m pip install -r {{ noaa_home }}/requirements.txt"
 ...

--- a/install_and_upgrade.sh
+++ b/install_and_upgrade.sh
@@ -41,6 +41,14 @@ if [ -f /etc/modprobe.d/rtlsdr.conf ]; then
   install_type='upgrade'
 fi
 
+log_running "Installing Python dependencies..."
+sudo python3 -m pip install -r $HOME/raspberry-noaa-v2/requirements.txt
+if [ $? -eq 0 ]; then
+  log_done "  Successfully aligned required Python packages!"
+else
+  die "  Could not install dependent Python packages - please check the logs above"
+fi
+
 # install ansible
 which ansible-playbook 2>&1 >/dev/null
 if [ $? -ne 0 ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ ephem==3.7.7.1
 idna==2.8
 numpy==1.18.1
 Pillow==7.1.2
-urllib3==1.25.8
+urllib3==1.21.1


### PR DESCRIPTION
Hard-code a previous version of urllib3 in the requirements.txt and have pip install this within the install script vs. Ansible to ensure the package is installed prior to Ansible being installed and possibly bringing in an incorrect version of the library.