### PR TITLE
Add Thermal Image Processing for NOAA

### DIFF
--- a/scripts/image_processors/noaa_therm.sh
+++ b/scripts/image_processors/noaa_therm.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Purpose: Produces a false colour image from NOAA APT images based on temperature.
+#          Provides a good way of visualising cloud temperatures. The palette used
+#          can be changed using the -P option.
+#
+# Input parameters:
+#   1. Map overlap file
+#   2. Input .wav file
+#   3. Output .jpg file
+#
+# Example:
+#   ./noaa_therm.sh /path/to/map_overlay.png /path/to/input.wav /path/to/output.jpg
+
+# import common lib and settings
+. "$HOME/.noaa-v2.conf"
+. "$NOAA_HOME/scripts/common.sh"
+
+# input params
+MAP_OVERLAY=$1
+INPUT_WAV=$2
+OUTPUT_IMAGE=$3
+
+# produce the output image
+$WXTOIMG -o -m "${MAP_OVERLAY}" -e "therm" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_za.sh
+++ b/scripts/image_processors/noaa_za.sh
@@ -11,7 +11,7 @@
 #   3. Output .jpg file
 #
 # Example:
-#   ./noaa_gp_ir_za.sh /path/to/map_overlay.png /path/to/input.wav /path/to/output.jpg
+#   ./noaa_za.sh /path/to/map_overlay.png /path/to/input.wav /path/to/output.jpg
 
 # import common lib and settings
 . "$HOME/.noaa-v2.conf"

--- a/scripts/receive_noaa.sh
+++ b/scripts/receive_noaa.sh
@@ -74,10 +74,10 @@ $WXMAP -T "${SAT_NAME}" -H "${TLE_FILE}" -p 0 ${extra_map_opts} -o "${epoch_adju
 
 # determine which enhancements to create based on sunlight/dark
 if [ "${SUN_ELEV}" -gt "${SUN_MIN_ELEV}" ]; then
-  ENHANCEMENTS="ZA MCIR MCIR-precip MSA MSA-precip HVC-precip HVCT-precip HVC HVCT"
+  ENHANCEMENTS="ZA MCIR MCIR-precip MSA MSA-precip HVC-precip HVCT-precip HVC HVCT therm"
   daylight="true"
 else
-  ENHANCEMENTS="ZA MCIR MCIR-precip"
+  ENHANCEMENTS="ZA MCIR MCIR-precip therm"
   daylight="false"
 fi
 
@@ -115,6 +115,9 @@ for enhancement in $ENHANCEMENTS; do
       ;;
     "HVCT-precip")
       proc_script="noaa_hvct_precip.sh"
+      ;;
+    "therm")
+      proc_script="noaa_therm.sh"
       ;;
   esac
 

--- a/webpanel/App/Models/Capture.php
+++ b/webpanel/App/Models/Capture.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace App\Models;
+use Config\Config;
 
 class Capture extends \Lib\Model {
     public $enhancements;
@@ -37,8 +38,7 @@ class Capture extends \Lib\Model {
     # get total number of pages to display images given the
     # passed number of images per page
     public function totalPages($images_per_page) {
-      $decoded_passes = $this->db_conn->querySingle("SELECT count()
-                                                     FROM decoded_passes;");
+      $decoded_passes = $this->db_conn->querySingle("SELECT count() FROM decoded_passes;");
       return ceil($decoded_passes/$images_per_page);
     }
 
@@ -46,6 +46,7 @@ class Capture extends \Lib\Model {
     public function getEnhancements($id) {
       $query = $this->db_conn->prepare('SELECT daylight_pass,
                                                sat_type,
+                                               file_path,
                                                img_count,
                                                has_spectrogram
                                         FROM decoded_passes
@@ -61,16 +62,20 @@ class Capture extends \Lib\Model {
           break;
         case 1: // NOAA
           if ($pass['daylight_pass'] == 1) {
-            $enhancements = ['-ZA.jpg','-MCIR.jpg','-MCIR-precip.jpg','-MSA.jpg','-MSA-precip.jpg','-HVC.jpg','-HVC-precip.jpg','-HVCT.jpg','-HVCT-precip.jpg'];
+            $enhancements = ['-ZA.jpg','-MCIR.jpg','-MCIR-precip.jpg','-MSA.jpg','-MSA-precip.jpg','-HVC.jpg','-HVC-precip.jpg','-HVCT.jpg','-HVCT-precip.jpg','-therm.jpg'];
           } else {
-            $enhancements = ['-ZA.jpg','-MCIR.jpg','-MCIR-precip.jpg'];
+            $enhancements = ['-ZA.jpg','-MCIR.jpg','-MCIR-precip.jpg','-therm.jpg'];
           }
           break;
-        case 2: // ISS
-          for ($x = 0; $x <= $pass['img_count']-1; $x++) {
-            $enhancements[] = "-$x.png";
-          }
-          break;
+      }
+
+      # remove any enhancements that do not actually exist for this capture
+      foreach ($enhancements as $e) {
+        $filepath = Config::IMAGE_PATH . '/' . $pass['file_path'] . $e;
+        if (!file_exists($filepath)) {
+          $key = array_search($e, $enhancements);
+          unset($enhancements[$key]);
+        }
       }
 
       # capture spectrogram if one exists
@@ -83,9 +88,7 @@ class Capture extends \Lib\Model {
 
     # get the image path for the specific image
     public function getImagePath($id) {
-      $query = $this->db_conn->prepare('SELECT file_path
-                                        FROM decoded_passes
-                                        WHERE id = ?;');
+      $query = $this->db_conn->prepare('SELECT file_path FROM decoded_passes WHERE id = ?;');
       $query->bindValue(1, $id);
       $result = $query->execute();
       $image = $result->fetchArray();
@@ -95,9 +98,7 @@ class Capture extends \Lib\Model {
 
     # get the epoch start time for the capture
     public function getStartEpoch($id) {
-      $query = $this->db_conn->prepare('SELECT pass_start
-                                        FROM decoded_passes
-                                        WHERE id = ?;');
+      $query = $this->db_conn->prepare('SELECT pass_start FROM decoded_passes WHERE id = ?;');
       $query->bindValue(1, $id);
       $result = $query->execute();
       $res = $result->fetchArray();


### PR DESCRIPTION
Add the ability to create a thermal image for NOAA, and error handling to ensure any variant to be displayed to the webpanel has an actual image file to be displayed (e.g. thermal images are only going to occur going forward - so we don't want an image placeholder to be in place for older captures that don't have a thermal variant). This logic was built more generically to strip out any filter that doesn't have an actual file available.