### PR TITLE
Add Telemetry Cropping

### DIFF
--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -28,3 +28,4 @@ PRUNE_OLDER_THAN={{ delete_older_than_n }}
 PRUNE_OLDEST={{ delete_oldest_n }}
 METEOR_RECEIVER={{ meteor_receiver }}
 FREQ_OFFSET={{ receiver_freq_offset }}
+NOAA_CROP_TELEMETRY={{ noaa_crop_telemetry|lower }}

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -32,8 +32,10 @@ delete_audio: false
 # processing settings
 #   flip_meteor_image - whether the meteor image should be flipped
 #   produce_spectrogram - whether to produce a spectrogram image of the audio recording
+#   noaa_crop_telemetry - whether to crop the left/right telemetry in image captures
 flip_meteor_image: true
 produce_spectrogram: true
+noaa_crop_telemetry: false
 
 # thresholds for scheduling captures - enables avoiding an attempt
 # to capture imagery if objects are lower than these degree elevation thresholds

--- a/scripts/image_processors/noaa_hvc.sh
+++ b/scripts/image_processors/noaa_hvc.sh
@@ -26,5 +26,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "HVC" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "HVC" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_hvc_precip.sh
+++ b/scripts/image_processors/noaa_hvc_precip.sh
@@ -26,5 +26,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "HVC-precip" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "HVC-precip" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_hvct.sh
+++ b/scripts/image_processors/noaa_hvct.sh
@@ -20,5 +20,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "HVCT" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "HVCT" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_hvct_precip.sh
+++ b/scripts/image_processors/noaa_hvct_precip.sh
@@ -20,5 +20,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "HVCT" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "HVCT" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_mcir.sh
+++ b/scripts/image_processors/noaa_mcir.sh
@@ -22,5 +22,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "MCIR" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "MCIR" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_mcir_precip.sh
+++ b/scripts/image_processors/noaa_mcir_precip.sh
@@ -22,5 +22,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "MCIR-precip" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "MCIR-precip" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_msa.sh
+++ b/scripts/image_processors/noaa_msa.sh
@@ -21,5 +21,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "MSA" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "MSA" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_msa_precip.sh
+++ b/scripts/image_processors/noaa_msa_precip.sh
@@ -21,5 +21,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "MSA-precip" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "MSA-precip" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_therm.sh
+++ b/scripts/image_processors/noaa_therm.sh
@@ -21,5 +21,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "therm" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "therm" "${INPUT_WAV}" "${OUTPUT_IMAGE}"

--- a/scripts/image_processors/noaa_za.sh
+++ b/scripts/image_processors/noaa_za.sh
@@ -22,5 +22,11 @@ MAP_OVERLAY=$1
 INPUT_WAV=$2
 OUTPUT_IMAGE=$3
 
+# calculate any extra args for the processor
+extra_args=""
+if [ "${NOAA_CROP_TELEMETRY}" == "true" ]; then
+  extra_args="-c"
+fi
+
 # produce the output image
-$WXTOIMG -o -m "${MAP_OVERLAY}" -e "ZA" "${INPUT_WAV}" "${OUTPUT_IMAGE}"
+$WXTOIMG -o -m "${MAP_OVERLAY}" ${extra_args} -e "ZA" "${INPUT_WAV}" "${OUTPUT_IMAGE}"


### PR DESCRIPTION
Add an option (default to false) to enable telemetry cropping to the NOAA image processing. Setting exists in the config/settings.yml.sample and should be copied into config/settings.yml, and then the ./install_and_upgrade.sh script run to align settings.