### PR TITLE
Add Configurable Image Annotation Location

### DIFF
--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -29,3 +29,4 @@ PRUNE_OLDEST={{ delete_oldest_n }}
 METEOR_RECEIVER={{ meteor_receiver }}
 FREQ_OFFSET={{ receiver_freq_offset }}
 NOAA_CROP_TELEMETRY={{ noaa_crop_telemetry|lower }}
+IMAGE_ANNOTATION_LOCATION={{ image_annotation_location }}

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -33,9 +33,12 @@ delete_audio: false
 #   flip_meteor_image - whether the meteor image should be flipped
 #   produce_spectrogram - whether to produce a spectrogram image of the audio recording
 #   noaa_crop_telemetry - whether to crop the left/right telemetry in image captures
+#   image_annotation_location - where to place the annotation in images - valid options are:
+#        NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast
 flip_meteor_image: true
 produce_spectrogram: true
 noaa_crop_telemetry: false
+image_annotation_location: 'NorthWest'
 
 # thresholds for scheduling captures - enables avoiding an attempt
 # to capture imagery if objects are lower than these degree elevation thresholds

--- a/scripts/image_processors/meteor_normalize_annotate.sh
+++ b/scripts/image_processors/meteor_normalize_annotate.sh
@@ -19,4 +19,4 @@ INPUT_JPG=$1
 ANNOTATION_TEXT=$2
 QUALITY=$3
 
-$CONVERT "${INPUT_JPG}" -channel rgb -normalize -undercolor black -fill yellow -pointsize 60 -annotate +20+60 "${ANNOTATION_TEXT}" "${INPUT_JPG}"
+$CONVERT "${INPUT_JPG}" -gravity $IMAGE_ANNOTATION_LOCATION -channel rgb -normalize -undercolor black -fill yellow -pointsize 18 -annotate +10+10 "${ANNOTATION_TEXT}" "${INPUT_JPG}"

--- a/scripts/image_processors/noaa_normalize_annotate.sh
+++ b/scripts/image_processors/noaa_normalize_annotate.sh
@@ -20,4 +20,4 @@ INPUT_JPG=$1
 ANNOTATION_TEXT=$2
 QUALITY=$3
 
-$CONVERT -quality $QUALITY -format jpg "${INPUT_JPG}" -undercolor black -fill yellow -pointsize 18 -annotate +20+20 "${ANNOTATION_TEXT}" "${INPUT_JPG}"
+$CONVERT -quality $QUALITY -format jpg "${INPUT_JPG}" -gravity $IMAGE_ANNOTATION_LOCATION -undercolor black -fill yellow -pointsize 18 -annotate +10+10 "${ANNOTATION_TEXT}" "${INPUT_JPG}"

--- a/scripts/receive_meteor.sh
+++ b/scripts/receive_meteor.sh
@@ -161,11 +161,11 @@ elif [ "$METEOR_RECEIVER" == "gnuradio" ]; then
     $CONVERT ${AUDIO_FILE_BASE}-col-rectified.jpg -rotate 180 -normalize -quality 90 ${AUDIO_FILE_BASE}-col.jpg
 
     log "Annotating images" "INFO"
-    convert "${AUDIO_FILE_BASE}.jpg" -channel rgb -normalize -undercolor black -fill yellow -pointsize 60 -annotate +20+60 "${annotation}" "${IMAGE_FILE_BASE}-122-rectified.jpg"
+    convert "${AUDIO_FILE_BASE}.jpg" -gravity $IMAGE_ANNOTATION_LOCATION -channel rgb -normalize -undercolor black -fill yellow -pointsize 60 -annotate +20+60 "${annotation}" "${IMAGE_FILE_BASE}-122-rectified.jpg"
     convert -thumbnail 300 "${IMAGE_FILE_BASE}-122-rectified.jpg" "${IMAGE_THUMB_BASE}-122-rectified.jpg"
-    convert "${AUDIO_FILE_BASE}-ir.jpg" -channel rgb -normalize -undercolor black -fill yellow -pointsize 60 -annotate +20+60 "${annotation}" "${IMAGE_FILE_BASE}-ir-122-rectified.jpg"
+    convert "${AUDIO_FILE_BASE}-ir.jpg" -gravity $IMAGE_ANNOTATION_LOCATION -channel rgb -normalize -undercolor black -fill yellow -pointsize 60 -annotate +20+60 "${annotation}" "${IMAGE_FILE_BASE}-ir-122-rectified.jpg"
     convert -thumbnail 300 "${IMAGE_FILE_BASE}-ir-122-rectified.jpg" "${IMAGE_THUMB_BASE}-ir-122-rectified.jpg"
-    convert "${AUDIO_FILE_BASE}-col.jpg" -channel rgb -normalize -undercolor black -fill yellow -pointsize 60 -annotate +20+60 "${annotation}" "${IMAGE_FILE_BASE}-col-122-rectified.jpg"
+    convert "${AUDIO_FILE_BASE}-col.jpg" -gravity $IMAGE_ANNOTATION_LOCATION -channel rgb -normalize -undercolor black -fill yellow -pointsize 60 -annotate +20+60 "${annotation}" "${IMAGE_FILE_BASE}-col-122-rectified.jpg"
     convert -thumbnail 300 "${IMAGE_FILE_BASE}-col-122-rectified.jpg" "${IMAGE_THUMB_BASE}-col-122-rectified.jpg"
 
     # insert or replace in case there was already an insert due to the spectrogram creation


### PR DESCRIPTION
Add the ability to specify where on images the annotation will exist, defaulting to NorthWest (upper left). Note that this is a universal setting that will apply to all images generated (not configurable by image type, satellite, etc.).