### PR TITLE
Add Feature and Documentation for DB Backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ There are and will be future "optional" features for this framework. Below is a 
 to enable/configure with links to the respective instructions:
 
 * [Pruning Old Images](docs/pruning.md)
+* [Database Backups](docs/db_backups.md)
 
 ## Changing Configurations After Install
 

--- a/db_backups/.gitignore
+++ b/db_backups/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/db_backups.md
+++ b/docs/db_backups.md
@@ -1,0 +1,29 @@
+![Raspberry NOAA](../assets/header_1600_v2.png)
+
+If you are worried about power failures or other data corrupting events, there is an ability to perform automated
+database backups for easier recovery of the database. To perform backups nightly and retain 3-days worth of backups
+(reasonable timeframe in case restoration is necessary), run the following command, which will cause the backup
+script to run after the nightly schedule job (ensuring you get latest captures backed up and there is no conflict
+of backing up mid-stream of scheduled passes being recorded):
+
+```bash
+# back up database nightly at 12:05AM local and retain 3 copies
+cat <(crontab -l) <(echo "5 0 * * * /home/pi/raspberry-noaa-v2/scripts/db_backup.sh") | crontab -
+```
+
+Backups will be created in the `db_backups` directory of this framework, with the last 3 days of backup files
+persisting while older files being pruned when the script runs. The names of the files follow the format of
+`panel.db.<YYYYMMDD>.backup`, where `YYYY` is the year, `MM` is the month, `DD` is the day of when the backup
+was taken.
+
+In the case of a failure or corrupt database, simply copy the backup desired over your existing `panel.db` SQL file
+like so (for example - obviously updating the filename to the backup filename you wish to use). Note that you should
+ensure that there are no scripts/captures running at the time of copy that could be updating the database at the
+same time (ideally):
+
+```bash
+cp /home/pi/raspberry-noaa-v2/db_backups/panel.db.20210212.backup /home/pi/raspberry-noaa-v2/db/panel.db
+```
+
+Following this copy/overwrite, visit your webpanel page and you should see data up to the last write to the
+database before it was backed up.

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Purpose: Perform backup of database - expected to run on a daily basis. Will
+#          perform a backup of the database followed by delete any backups present
+#          that are older than 3 days old (reasonable retention).
+
+# import common lib and settings
+. "$HOME/.noaa-v2.conf"
+. "$NOAA_HOME/scripts/common.sh"
+
+#Generate date since epoch in seconds - days
+dt=$(date +"%Y%m%d")
+
+log "Backing up database..." "INFO"
+$SQLITE3 "${NOAA_HOME}/db/panel.db" ".backup '$NOAA_HOME/db_backups/panel.db.$dt.backup'"
+
+log "Pruning database backups older than 3 days..." "INFO"
+find "${NOAA_HOME}/db_backups/" -type f -mtime +3 -name panel.db.*.backup


### PR DESCRIPTION
Add a feature that can be implemented to take a backup of the SQLite3 database on a nightly basis, retaining 3 days of backups in case of disaster or corruption in the database. Add documentation to supplement.