### PR TITLE
Update Email for Defaults and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ to enable/configure with links to the respective instructions:
 
 * [Pruning Old Images](docs/pruning.md)
 * [Database Backups](docs/db_backups.md)
+* [Emailing Images (IFTTT)](docs/emailing.md)
 
 ## Changing Configurations After Install
 

--- a/ansible/roles/common/files/email-logrotate-settings
+++ b/ansible/roles/common/files/email-logrotate-settings
@@ -1,0 +1,8 @@
+/var/log/msmtp/*.log {
+  missingok
+  daily
+  rotate 7
+  nocompress
+  notifempty
+  create 0700 pi pi
+}

--- a/ansible/roles/common/files/msmtprc
+++ b/ansible/roles/common/files/msmtprc
@@ -1,0 +1,15 @@
+defaults
+auth           on
+tls            on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        /var/log/msmtp/output.log
+
+# gmail TLS-enabled SMTP configuration
+account        gmail
+host           smtp.gmail.com
+port           587
+from           <YOUR_EMAIL_ADDRESS>
+user           <YOUR_ACCOUNT_USER_ID>
+password       <YOUR_ACCOUNT_PASSWORD>
+
+account default : gmail

--- a/ansible/roles/common/tasks/dependencies.yml
+++ b/ansible/roles/common/tasks/dependencies.yml
@@ -27,17 +27,6 @@
       - sox
       - sqlite3
 
-- name: install mpack and msmtp if emailing is enabled
-  become: yes
-  apt:
-    update_cache: no
-    state: present
-    name:
-      - mpack
-      - msmtp
-      - msmtp-mta
-  when: enable_email_push | bool
-
 - name: install dependencies (stretch only)
   become: yes
   apt:

--- a/ansible/roles/common/tasks/email.yml
+++ b/ansible/roles/common/tasks/email.yml
@@ -1,0 +1,51 @@
+---
+- name: install mpack and msmtp if emailing is enabled
+  become: yes
+  apt:
+    update_cache: no
+    state: present
+    name:
+      - mpack
+      - msmtp
+      - msmtp-mta
+  when: enable_email_push | bool
+
+- name: drop template email msmtp config file
+  copy:
+    src: msmtprc
+    dest: /home/pi/.msmtprc
+    force: no
+    owner: pi
+    group: pi
+    mode: 0600
+  when: enable_email_push | bool
+
+- name: create an msmtp log directory
+  become: yes
+  file:
+    path: /var/log/msmtp
+    state: directory
+    owner: pi
+    group: pi
+    mode: 0750
+  when: enable_email_push | bool
+
+- name: create an msmtp starter log with permissions
+  become: yes
+  file:
+    path: /var/log/msmtp/output.log
+    owner: pi
+    group: pi
+    mode: 0644
+    state: touch
+  when: enable_email_push | bool
+
+- name: logrotate settings for msmtp
+  become: yes
+  copy:
+    src: email-logrotate-settings
+    dest: /etc/logrotate.d/msmtp
+    owner: root
+    group: root
+    mode: 0644
+...

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -16,4 +16,7 @@
 
 # ramfs setup
 - include: ramfs.yml
+
+# email setup
+- include: email.yml
 ...

--- a/docs/emailing.md
+++ b/docs/emailing.md
@@ -1,0 +1,63 @@
+![Raspberry NOAA](../assets/header_1600_v2.png)
+
+In `config/settings.yml`, setting `enable_email_push: true` and configuring an `email_push_address` will enable pushing all
+captured, processed images to a destination email address. This is useful when configuring services such as If This Then That
+(IFTTT) to accept the email with the subject and email attachment and post it to services such as Facebook, Twitter, or other
+locations to store your images. Below outlines how to accomplish this, with this framework installing a basic
+`/home/pi/.msmtprc` file that enables configuring a gmail account to email images with.
+
+**Note**: You need an existing email address that you have full access to in order to configure sending - this configuration
+will use that email address credentials for sending emails from your receiver device.
+
+**WARNING**: MAKE SURE YOU KEEP THE CONFIG FILE LOCKED DOWN! This file (`/home/pi/.msmtprc`) will contain your email credentials,
+and is by default written to the file system as read/write only by the `pi` user. This is why it's extremely important to not
+expose your Pi to the public internet unless you absolutely know what you're doing when it comes to security, and at a minimum,
+absolutely change the `pi` user default password to something HIGHTLY complex and hard to hack!
+
+## Configure Settings and Update
+
+To enable this functionality, first update your `config/settings.yml` to set `enable_email_push: true` and set an email
+address to forward images to as `email push address`. Then, re-run the installer script `./install_and_upgrade.sh`, which will
+align your environment to install dependencies and requirements, including a `/home/pi/.msmtprc` file that has defaults for
+configuring a gmail account to send emails.
+
+## Configure Email Settings
+
+Once the installer has been run, you should see a settings file in your `pi` user home directory named `/home/pi/.msmtprc`.
+Edit this file for your email settings, including adding your gmail credentials for the email address you wish to use to send
+the image emails to your target address.
+
+**Note**: that if you are running Multi-Factor Authentication (sometimes known as 2-Step Verification), you will need to obtain
+an App Password for your account and use this in place of your login credentials in order to allow the `mpack` binary to
+'bypass' Multi-Factor Authentication when sending emails autonomously. Follow the instructions in
+[this article](https://support.google.com/mail/answer/185833?hl=en#app-passwords) to configure an app password for your setup
+and use this within the `/home/pi/.msmtprc` file for the `password` setting.
+
+**Note**: This file defaults to a template to configure a gmail email account to send images. If you want to know more about
+how to configure this file for additional account types, see the [msmtp](https://wiki.debian.org/msmtp) documentation.
+
+## Testing (Optional)
+
+If you'd like to see whether the configurations you've set are working, you can run a quick test from the command line using
+an exsting image (or any image for that matter). Simply run the following below, replacing `<DEST_EMAIL>` with an email
+address you want to send the email to (such as the one configured in your `config/settings.yml` file, for example):
+
+```bash
+mpack -s "This is a test" /srv/images/NOAA-18-20210211-205249-MCIR.jpg <DEST_EMAIL>
+```
+
+If all goes well, an email will be sent to `<DEST_EMAIL>` with the subject "This is a test" and the body of the email
+containing the image specified as an attachment. This indicates your configuration is ready to go and all new images should
+successfully be emailed to this destination!
+
+## Profit
+
+Once the above have been performed, simply wait until your next capture occurs and you should then see an email show up
+in your target email address. If this is a destination service such as IFTTT that is configured to post images to a Facebook
+page, for example, the image should be posted to the page with text from the annotation that is built alongside the capture!
+
+## Troubleshooting
+
+If you aren't receiving emails at the destination configured, inspect the `/var/log/msmtp/output.log` file for errors that
+might be occurring. This file is also good to consult in general as it contains information about emails being sent that were
+successful.


### PR DESCRIPTION
Update framework to drop default configurations and add documentation to detail how to configure email forwarding, including the nuances of using a GMail account with MFA enabled.