### PR TITLE
Add Config Diff Script and Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ and all of your content will automatically upgrade (obviously you'll want to do 
 or about to occur). Note that once you pull the latest code down using git, you'll likely want to compare your `config/settings.yml`
 file with the new code `config/settings.yml.sample` and include/incorporate any new or renamed configuration parameters.
 
+**Note**: You can double-check that the configuration parameters required exist in your configuration file (this is done by default
+now as part of the `install_and_upgrade.sh` script) by running `./scripts/diff_yaml_configs.sh config/settings.yml config/settings.yml.sample`.
+The output of this script will inform you whether there are any new configs that you need to add to your `config/settings.yml` file
+to help with reducing the strain on your eyes in comparing the files.
+
 ```bash
 # pull down new code
 cd $HOME/raspberry-noaa-v2/

--- a/install_and_upgrade.sh
+++ b/install_and_upgrade.sh
@@ -41,6 +41,14 @@ if [ -f /etc/modprobe.d/rtlsdr.conf ]; then
   install_type='upgrade'
 fi
 
+log_running "Checking configuration files..."
+python3 scripts/diff_yaml_configs.py config/settings.yml.sample config/settings.yml
+if [ $? -eq 0 ]; then
+  log_done "  Config check complete!"
+else
+  die "  Please update your config/settings.yml file to include the missing parameters from config/settings.yml.sample"
+fi
+
 log_running "Installing Python dependencies..."
 sudo python3 -m pip install -r $HOME/raspberry-noaa-v2/requirements.txt
 if [ $? -eq 0 ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ ephem==3.7.7.1
 idna==2.8
 numpy==1.18.1
 Pillow==7.1.2
-urllib3==1.26.3
+pyyaml==3.13
 requests==2.25.1
+urllib3==1.26.3

--- a/scripts/diff_yaml_configs.py
+++ b/scripts/diff_yaml_configs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Purpose: Parse 2 yaml config files and return any 'missing' config
+#          parameters in the first input file that exists in the second.
+#
+# Parameters:
+#   1. Base file that should be considered complete/accurate
+#   2. File to be checked
+#
+# Example:
+#   ./diff_yaml_configs.py config/pristine.yml config/my_config.yml
+import sys
+import yaml
+from os import path
+
+def diff_configs(pristine, check):
+  '''
+  Perform a basic key/value check to ensure all config keys in
+  pristine exist in check, and return a list of deltas, if any
+  '''
+
+def main():
+  '''
+  Main function to check for usage, accept arguments from command
+  line, and load yaml files into dictionaries
+  '''
+
+  # check for correct usage
+  if (len(sys.argv) != 3):
+    print("Usage: ./diff_yaml_configs.py <path_to_pristine_config> <path_to_check_config>")
+    exit(1)
+
+  # input arguments
+  pristine_config = sys.argv[1]
+  check_config = sys.argv[2]
+
+  # check that files specified exist/are accessible
+  if (not path.exists(pristine_config)):
+    print("ERROR: Pristine config file '%s' not found or inaccessible" % pristine_config)
+    exit(1)
+
+  # check that files specified exist/are accessible
+  if (not path.exists(check_config)):
+    print("ERROR: Check config file '%s' not found or inaccessible" % check_config)
+    exit(1)
+
+  pristine = yaml.load(open(pristine_config), Loader=yaml.SafeLoader)
+  check = yaml.load(open(check_config), Loader=yaml.SafeLoader)
+
+  # perform check and print any missing keys
+  missing = set(pristine.keys()) - set(check.keys())
+  if len(missing) > 0:
+    delta  = "ERROR: Missing configs in '%s' that exist in '%s'\n\n" % (pristine_config, check_config)
+    delta += "Below are a list of missing configs and their defaults in the pristine config.\n"
+    for c in missing:
+      delta += "  %s: %s\n" % (c, pristine[c])
+
+    print(delta)
+    exit(1)
+  else:
+    print("Configurations '%s' and '%s' aligned" % (pristine_config, check_config))
+    exit(0)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Add a diff script that helps compare configuration files and update the documentation on how this can be used (this is now also part of the default installer).