### PR TITLE
Add Satvis Focus on Satellite

### DIFF
--- a/webpanel/App/Views/Passes/index.html
+++ b/webpanel/App/Views/Passes/index.html
@@ -37,7 +37,12 @@
 
           <tr{% if pass.is_active == false or pass_end < now %} class="inactive"{% endif %}>
             <td{% if prev_pass_end >= pass.pass_start %} class="conflict"{% endif %}>
-              {% if prev_pass_end >= pass.pass_start %}<i class="fa fa-exclamation-triangle conflict-icon" data-toggle="tooltip" data-placement="right" title="{{ lang['conflicting_pass'] }}"></i>{% endif %} {{ pass.sat_name }}
+              {% if prev_pass_end >= pass.pass_start %}<i class="fa fa-exclamation-triangle conflict-icon" data-toggle="tooltip" data-placement="right" title="{{ lang['conflicting_pass'] }}"></i>{% endif %}
+              {% if constant('Config\\Config::ENABLE_SATVIS') == 'true' %}
+                <a href='https://satvis.space/?elements=Point,Label,Orbit%20track,Sensor%20cone&layers=OfflineHighres&tags=Weather&sat={{ pass.sat_name }}' target='satvis'>{{ pass.sat_name }}</a>
+              {% else %}
+                {{ pass.sat_name }}
+              {% endif %}
             </td>
             <td class="text-center">{{ pass_start }}</td>
             <td class="text-center">{{ pass_end }}</td>


### PR DESCRIPTION
Change satellite names to hyperlinks when the Satvis view is enabled in the pass list, enabling clicking on a satellite name and "focusing" on the satellite in the Satvis view when clicked.