### PR TITLE
Fix a Relative Path Issue in Scanner Script

### DIFF
--- a/scripts/testing/generate_waterfall.sh
+++ b/scripts/testing/generate_waterfall.sh
@@ -9,10 +9,11 @@
 #   ./generate_waterfall.sh scan.csv.gz
 
 [ $# -lt 1 ] && echo "usage: $0 inputfile" && exit -1
+scriptpath="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 infile=$1
 outfile=$1.png
 
 echo "generating $outfile from $infile.
 This may take a while, maybe get a coffee?"
-./heatmap.py --ytick 60m $infile $outfile
+$scriptpath/heatmap.py --ytick 60m $infile $outfile


### PR DESCRIPTION
Update the waterfall generator to use absolute path so it doesn't fail when run from a different directory.