### PR TITLE
Add Ability to TLS-Eanble Webpanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ vi config/settings.yml
 Once complete, follow the [migration document](docs/migrate_from_raspberry_noaa.md) if you want to migrate from the original raspberry-noaa
 to this version 2 (keep your previous captures and make them visible).
 
+In addition, if you have elected to run a TLS-enabled web server, see [THIS LINK](docs/tls_webserver.md) for some additional information
+on how to handle self-signed certificates when attempting to visit your webpanel.
+
 To see what occurred during a capture event, check out the log file `/var/log/raspberry-noaa-v2/output.log`.
 
 ## Why a Version 2?
@@ -122,6 +125,9 @@ vi config/settings.yml
 Once the script completes, you can either follow the [migration document](docs/migrate_from_raspberry_noaa.md) (if you had previously
 been using raspberry-noaa on this device) or, if this is a brand new setup, just visit the webpanel and get going!
 
+**NOTE**: If you have elected to run a TLS-enabled web server, see [THIS LINK](docs/tls_webserver.md) for some additional information
+on how to handle self-signed certificates when attempting to visit your webpanel.
+
 ## Upgrade
 
 Want to get the latest and greatest content from the GitHub master branch? Easy - use the same script from the Install process
@@ -147,6 +153,9 @@ git pull
 # perform upgrade
 ./install_and_upgrade.sh
 ```
+
+If you have elected to run a TLS-enabled web server, see [THIS LINK](docs/tls_webserver.md) for some additional information
+on how to handle self-signed certificates when attempting to visit your webpanel.
 
 ## Post Install
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -21,4 +21,8 @@ ramfs_path: "/var/ramfs"
 
 # log output file
 log_file: "/var/log/raspberry-noaa-v2/output.log"
+
+# TLS self-signed certs
+tls_cert: /etc/ssl/certs/local_server.crt
+tls_cert_key: /etc/ssl/private/local_server.key
 ...

--- a/ansible/roles/webserver/tasks/main.yml
+++ b/ansible/roles/webserver/tasks/main.yml
@@ -82,6 +82,25 @@
     mode: 0644
   notify: restart nginx
 
+- name: nginx non-tls config symlink
+  become: yes
+  file:
+    src: /etc/nginx/sites-available/default
+    dest: /etc/nginx/sites-enabled/default
+    state: link
+    owner: root
+    group: root
+  when: enable_non_tls|bool
+  notify: restart nginx
+
+- name: remove non-tls site enable if disabled
+  become: yes
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  when: not enable_non_tls|bool
+  notify: restart nginx
+
 - name: update images directory group
   become: yes
   file:
@@ -109,4 +128,54 @@
     path: "{{ noaa_home }}/db/panel.db"
     group: www-data
     mode: 0770
+
+- name: check if self-signed certificate is expired
+  command: openssl x509 -checkend 86400 -noout -in /etc/ssl/certs/local_server.crt
+  register: cert_valid
+  failed_when: no
+  changed_when: no
+  when: enable_tls|bool
+
+- name: create self-signed certificate
+  become: yes
+  command: >
+    openssl req -x509 -nodes -subj '/CN={{ web_hostname }}' -days {{ cert_valid_days }}
+    -newkey rsa:4096 -sha256 -keyout {{ tls_cert_key }} -out {{ tls_cert }}
+  when: enable_tls|bool and cert_valid.rc != 0
+
+- name: nginx tls config file
+  become: yes
+  template:
+    src: nginx_tls_default.j2
+    dest: /etc/nginx/sites-available/default-tls
+    owner: root
+    group: root
+    mode: 0644
+  when: enable_tls|bool
+  notify: restart nginx
+
+- name: nginx tls config symlink
+  become: yes
+  file:
+    src: /etc/nginx/sites-available/default-tls
+    dest: /etc/nginx/sites-enabled/default-tls
+    state: link
+    owner: root
+    group: root
+  when: enable_tls|bool
+  notify: restart nginx
+
+- name: remove tls site enable if disabled
+  become: yes
+  file:
+    path: /etc/nginx/sites-enabled/default-tls
+    state: absent
+  when: not enable_tls|bool
+  notify: restart nginx
+
+- name: ensure nginx is running
+  become: yes
+  service:
+    name: nginx
+    state: started
 ...

--- a/ansible/roles/webserver/templates/nginx_tls_default.j2
+++ b/ansible/roles/webserver/templates/nginx_tls_default.j2
@@ -1,5 +1,10 @@
 server {
-  listen {{ web_port }};
+  listen {{ web_tls_port }};
+
+  ssl on;
+  ssl_certificate {{ tls_cert }};
+  ssl_certificate_key {{ tls_cert_key }};
+
   root {{ web_home }}/public/;
   index index.php index.html index.htm index.nginx-debian.html;
   autoindex on;

--- a/ansible/webserver.yml
+++ b/ansible/webserver.yml
@@ -8,5 +8,11 @@
   post_tasks:
     - name: output web server url
       debug:
-        msg: "Your web server URL is: http://<hostname_or_ip>:{{ web_port }}"
+        msg: "Your non-TLS web server URL is: http://{{ web_server_name }}:{{ web_port }}"
+      when: not enable_tls|bool
+
+    - name: output web server tls url
+      debug:
+        msg: "Your TLS-enabled web server URL is: https://{{ web_server_name }}:{{ web_tls_port }}"
+      when: enable_tls|bool
 ...

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -106,8 +106,22 @@ noaa_map_state_border_color: "0xffff00"
 timezone: America/New_York
 lang_setting: en
 
-# port to run the webpanel on
+# web server configuration settings
+#   web_server_name - server name to use for the TLS certs and web endpoint - this MUST be
+#                     resolvable to the IP of this host (if you don't have DNS, simply use
+#                     the IP of the Raspberry Pi host)
+#   enable_non_tls - whether to enable a clear-text web listener (default port 80)
+#   web_port - port to run the web server clear-text (non-encrypted) endpoint on
+#   enable_tls - whether to enable the TLS-encrypted web listener (default port 443)
+#   web_tls_port - port to run the TLS listener on
+#   cert_valid_days - number of days the TLS certificates should be valid for - note that
+#                     you will need to re-install the certificates once this timeline expires
+web_server_name: raspberry-noaa.localdomain
+enable_non_tls: false
 web_port: 80
+enable_tls: true
+web_tls_port: 443
+cert_valid_days: 365
 
 # log level for output from scripts
 log_level: DEBUG

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -50,11 +50,20 @@
       "type": "string",
       "enum": [ "ar", "bg", "de", "en", "es", "fr", "nl", "sr" ]
     },
+    "web_server_name": { "type": "string" },
+    "enable_non_tls":  { "type": "boolean" },
     "web_port": {
       "type": "number",
       "minimum": 1,
       "maximum": 65534
     },
+    "enable_tls": { "type": "boolean" },
+    "web_tls_port": {
+      "type": "number",
+      "minimum": 1,
+      "maximum": 65534
+    },
+    "cert_valid_days": { "type": "number" },
     "log_level": {
       "type": "string",
       "enum": [ "DEBUG", "WARN", "INFO", "ERROR" ]
@@ -107,7 +116,12 @@
     "noaa_map_state_border_color",
     "timezone",
     "lang_setting",
+    "web_server_name",
+    "enable_non_tls",
     "web_port",
+    "enable_tls",
+    "web_tls_port",
+    "cert_valid_days",
     "log_level",
     "enable_satvis",
     "delete_oldest_n",

--- a/docs/tls_webserver.md
+++ b/docs/tls_webserver.md
@@ -24,3 +24,12 @@ TLS-enabled site (or when certificates are rotated):
 Note that the above are know to work at the time of this article being written but may change, and are obviously
 not applicable for other browsers. See the browser documentation for the browser you are using in order to figure
 out how to access the site with the self-signed certificate.
+
+## TLS Certificate Rotation
+
+By default, the configuration parameter `cert_valid_days` is set to `365` unless configured differently in your
+`config/settings.yml` file. This is the number of days the TLS certificate will be valid for before expiring.
+Once a certificate expires, a browser will very likely (and rightfully so) block you from accessing the webpanel.
+If this occurs, re-run the `./install_and_upgrade.sh` script which has the ability to detect an expired (or expiring
+within the next 24-hours) certificate and re-generate a new certificate/install it for use and automatically
+restart your webpanel services.

--- a/docs/tls_webserver.md
+++ b/docs/tls_webserver.md
@@ -1,0 +1,26 @@
+![Raspberry NOAA](../assets/header_1600_v2.png)
+
+## TLS-Enabling Your Webpanel
+
+This framework includes the ability to run your web server using TLS for encryption using self-signed certificates.
+In a future revision, this may be enhanced to support "bring your own" certificates as self-signed certificates
+are not "security approved" per-se, but this minimal configuration enables the ability to do things such as
+password-protect the Admin endpoint of the webpanel when TLS is enabled in order to help prevent (but not eliminate)
+the possibility of password sniffing.
+
+However, some web browsers such as Google Chrome do not allow access to servers with self-signed certificates by
+default. In these browsers, there is usually a warning when attempting to visit the page, sometimes with an option
+to "Continue anyways". In some cases (again, such as Google Chrome) this option is unavailable, but there is a
+workaround. If you attempt to visit your web server on the TLS-enabled port in Google Chrome but are blocked from
+doing so, when you visit the page in the browser, click anywhere with your mouse and type one of the following
+words on your keyboard (note, nothing will show up when typing this, but if you type the word correctly, Chrome
+should automatically forward you to the site). This should only be needed the very first time you visit the
+TLS-enabled site (or when certificates are rotated):
+
+* Chrome Version 65: Type the word `thisisunsafe`
+* Chrome Versions 62-64: Type the word `badidea`
+* Older Versions: Type the word `danger`
+
+Note that the above are know to work at the time of this article being written but may change, and are obviously
+not applicable for other browsers. See the browser documentation for the browser you are using in order to figure
+out how to access the site with the self-signed certificate.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -155,3 +155,12 @@ Below are some useful commands in a more summary fashion:
 * Read the main log file: `less /var/log/raspberry-noaa-v2/output.log`
 * List the scheduled passes: `atq`
 * Cancel a pass: `atrm <job_id>`
+
+# Webpanel Expired Certificate
+
+If you have enabled TLS for your webpanel and when visiting your webpanel the browser blocks you due to an expired certificate,
+simply re-run the `install_and_upgrade.sh` script. This script has the ability to detect expired certificates (or expiring
+within the next 24 hours) and will automatically remediate the problem by creating new certificates and installing them
+appropriately. After running this script, you should be able to resume accessing the webpanel, but you will also likely need
+to follw the instructions in the [TLS Webserver](tls_webserver.md) document regarding bypassing self-signed blocks in certain
+browsers the very first time you access the webpanel since the certificate will be brand new to the browser.

--- a/install_and_upgrade.sh
+++ b/install_and_upgrade.sh
@@ -131,10 +131,9 @@ echo "--------------------------------------------------------------------------
 log_finished "CONGRATULATIONS!"
 echo ""
 log_finished "raspberry-noaa-v2 has been successfully installed/upgraded!"
-log_finished "You can view the webpanel updates by visiting the following URL in a web browser:"
-log_finished "http://<YOUR_IP_OR_HOSTNAME>:<CONFIGURED_PORT>/"
 echo ""
-log_finished "You can also see the URL listed in the 'output web server url' play output above."
+log_finished "You can view the webpanel updates by visiting the URL(s) listed in the"
+log_finished "'output web server url' and 'output web server tls url' play outputs above."
 echo "-------------------------------------------------------------------------------"
 echo ""
 


### PR DESCRIPTION
Add the ability for users to TLS-enabled their webpanel using self-signed certificates (not ideal, but quick enough so we can start to add simple auth without exposing sensitive information in the clear). This is by no means a "best practice" implementation - it is a quick and dirty solution to get to "encrypted in flight" in order to protect passwords that are going to be used to protect the admin interface.