### PR TITLE
Add Admin Webpanel Page Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Once complete, follow the [migration document](docs/migrate_from_raspberry_noaa.
 to this version 2 (keep your previous captures and make them visible).
 
 In addition, if you have elected to run a TLS-enabled web server, see [THIS LINK](docs/tls_webserver.md) for some additional information
-on how to handle self-signed certificates when attempting to visit your webpanel.
+on how to handle self-signed certificates when attempting to visit your webpanel and enabling auth for the admin pages.
 
 To see what occurred during a capture event, check out the log file `/var/log/raspberry-noaa-v2/output.log`.
 
@@ -126,7 +126,7 @@ Once the script completes, you can either follow the [migration document](docs/m
 been using raspberry-noaa on this device) or, if this is a brand new setup, just visit the webpanel and get going!
 
 **NOTE**: If you have elected to run a TLS-enabled web server, see [THIS LINK](docs/tls_webserver.md) for some additional information
-on how to handle self-signed certificates when attempting to visit your webpanel.
+on how to handle self-signed certificates when attempting to visit your webpanel and enabling auth for the admin pages.
 
 ## Upgrade
 
@@ -155,7 +155,7 @@ git pull
 ```
 
 If you have elected to run a TLS-enabled web server, see [THIS LINK](docs/tls_webserver.md) for some additional information
-on how to handle self-signed certificates when attempting to visit your webpanel.
+on how to handle self-signed certificates when attempting to visit your webpanel and enabling auth for the admin pages.
 
 ## Post Install
 

--- a/ansible/roles/webserver/templates/Config.php.j2
+++ b/ansible/roles/webserver/templates/Config.php.j2
@@ -34,6 +34,10 @@ class Config {
   # which enhancements to display for day/night
   const NOAA_DAY_ENHANCEMENTS = '{{ noaa_daytime_enhancements }}';
   const NOAA_NIGHT_ENHANCEMENTS = '{{ noaa_nighttime_enhancements }}';
+
+  # admin endpoint auth
+  const ADMIN_USER = '{{ admin_username }}';
+  const ADMIN_PASS = '{{ admin_password }}';
 }
 
 ?>

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -116,12 +116,22 @@ lang_setting: en
 #   web_tls_port - port to run the TLS listener on
 #   cert_valid_days - number of days the TLS certificates should be valid for - note that
 #                     you will need to re-install the certificates once this timeline expires
+#   lock_admin_page - whether to require username/password when attempting to access the admin page
+#                     of the webpanel - WARNING: DO NOT SET THIS TO TRUE UNLESS YOU ONLY HAVE A TLS
+#                     ENABLED SITE - SETTING TO TRUE AND RUNNING A CLEARTEXT SITE IS ALMOST CERTAINLY
+#                     ASKING FOR YOUR CREDENTIALS TO BE STOLEN MID-REQUEST
+#   admin_username - username used to access the 'admin' endpoint of the webpanel (WARNING: see 'lock_admin_page' above)
+#   admin_password - password used to access the 'admin' endpoint of the webpanel (WARNING: see 'lock_admin_page' above)
+#                    NOTE: MAKE SURE YOU SET THIS TO SOMETHING REASONABLY COMPLICATED!
 web_server_name: raspberry-noaa.localdomain
 enable_non_tls: false
 web_port: 80
 enable_tls: true
 web_tls_port: 443
 cert_valid_days: 365
+lock_admin_page: false
+admin_username: 'admin'
+admin_password: 'admin'
 
 # log level for output from scripts
 log_level: DEBUG

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -64,6 +64,9 @@
       "maximum": 65534
     },
     "cert_valid_days": { "type": "number" },
+    "lock_admin_page": { "type": "boolean" },
+    "admin_username":  { "type": "string" },
+    "admin_password":  { "type": "string" },
     "log_level": {
       "type": "string",
       "enum": [ "DEBUG", "WARN", "INFO", "ERROR" ]
@@ -122,6 +125,9 @@
     "enable_tls",
     "web_tls_port",
     "cert_valid_days",
+    "lock_admin_page",
+    "admin_username",
+    "admin_password",
     "log_level",
     "enable_satvis",
     "delete_oldest_n",

--- a/docs/tls_webserver.md
+++ b/docs/tls_webserver.md
@@ -42,3 +42,40 @@ Once a certificate expires, a browser will very likely (and rightfully so) block
 If this occurs, re-run the `./install_and_upgrade.sh` script which has the ability to detect an expired (or expiring
 within the next 24-hours) certificate and re-generate a new certificate/install it for use and automatically
 restart your webpanel services.
+
+## Password Protecting Admin Page
+
+The Admin page in the webpanel allows for destructive activities such as deleting previous captures. In order to
+protect this page, you may elect to enable basic auth with a simple username/password scheme. The method used for
+this implementation is a VERY basic PHP code implementation that forces client authentication according to
+[this post](https://www.php.net/manual/en/features.http-auth.php).
+
+**WARNING**: Only enable this functionality if you are solely running a TLS-enabled web server. Enabling auth
+without having the web server TLS-enabled means that when credentials are entered in the browser, they are sent
+in clear text (non-encrypted), heightening the chances of being seen and stolen. Again (see all warnings above), while
+TLS-enabling your web server should still not be considered "sufficient" for exposing this framework on the public
+internet, you should definitely NOT enable auth on the Admin page *without* at least having TLS enabled.
+
+To enable protection of the admin page, update the following parameters in your `config/settings.yml` file (see the
+`config/settings.yml.sample` file for details on each of the parameters):
+
+```bash
+lock_admin_page: true
+admin_username: 'admin'
+admin_password: 'secretpass'
+```
+
+Obviously update the `admin_username` and `admin_password` to be the credentials you wish to use in order to access
+the page. For the password, ensure you use a reasonably complex password that is hard to guess (and also hard to
+hack via brute-force, rainbow lists, or other means).
+
+Once you've updated the configs appropriately, re-run the `install_and_upgrade.sh` script, at which point a visit to
+your Admin page in the webpanel should prompt you for a username and password. Enter the credentials you specified
+in the above configs and you should be logged in.
+
+As a note - the credentials establish a session for the user on first login. This session does not have an expiry
+unless the session details are removed from the browser or the server is restarted. Different browsers have different
+implementations of expiry and credential handling so there is no easy way to articulate each and every variant. If you
+are wondering whether your Admin page is still secured, you can open an "Incognito" window in a Chrome browser and
+attempt to access the page, which should prompt you for the username and password since incognito sessions do not
+use session variables.

--- a/webpanel/App/Controllers/AdminController.php
+++ b/webpanel/App/Controllers/AdminController.php
@@ -6,6 +6,19 @@ use Lib\View;
 use Config\Config;
 
 class AdminController extends \Lib\Controller {
+  # perform authentication prior to access any admin endpoint
+  # NOTE: This is a CHEAP method of security and not recommended as
+  #       "sufficient" to enable exposing things on the public internet.
+  protected function before() {
+    if (!isset($_SERVER['PHP_AUTH_USER']) ||
+        ($_SERVER['PHP_AUTH_USER'] != Config::ADMIN_USER || $_SERVER['PHP_AUTH_PW'] != Config::ADMIN_PASS)) {
+      header('WWW-Authenticate: Basic realm="raspberry-noaa-v2"');
+      header('HTTP/1.0 401 Unauthorized');
+      echo 'Auth required';
+      exit;
+    }
+  }
+
   public function indexAction($args) {
     $capture = $this->loadModel('Capture');
     $total_pages = $capture->totalPages(Config::ADMIN_CAPTURES_PER_PAGE);


### PR DESCRIPTION
Add the ability to provide basic auth for the Admin page functionality. Note that this is a VERY basic implementation and non-ideal but does afford the user the ability to specify a reasonably complex username and password to help protect the page.