### PR TITLE
Add reboot scheduling directive

### DIFF
--- a/ansible/roles/common/tasks/tools.yml
+++ b/ansible/roles/common/tasks/tools.yml
@@ -46,9 +46,15 @@
 
 - name: create scheduling cron job
   cron:
-    name: schedule passes
+    name: schedule passes daily
     minute: 1
     hour: 0
+    job: "{{ noaa_home }}/scripts/schedule.sh"
+
+- name: create scheduling cron job @ reboot
+  cron:
+    name: schedule passes after reboot
+    special_time: reboot
     job: "{{ noaa_home }}/scripts/schedule.sh"
 
 - name: create database


### PR DESCRIPTION
This adds a `@reboot` directive to ansible.
Especially when rebooting after the first install (as instructed), and also after an unexpected reboot, the scheduled at-jobs are lost.
This fixes that.