### PR TITLE
Ensure Scanner Stop Terminates Existing Scripts

### DIFF
--- a/scripts/testing/stop_and_finalize_scanning.sh
+++ b/scripts/testing/stop_and_finalize_scanning.sh
@@ -12,6 +12,13 @@
 
 scriptpath=$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
 
+# check if existing stop script is already running and
+# terminate that instance of it
+stopPid=$(ps -Alef | grep stop_and_finalize_scanning | grep sleep | awk '{print $4}')
+if [ ! -z "${stopPid}" ]; then
+  kill $stopPid
+fi
+
 killall rtl_power
 $scriptpath/generate_waterfall.sh $1
 rm $1


### PR DESCRIPTION
Ensure when the scanner stop is run it terminates the existing script that is sleeping in the background (cleanup).