### PR TITLE
Add Extend for Annotation

### DIFF
--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -62,6 +62,7 @@ PRUNE_OLDEST={{ delete_oldest_n }}
 METEOR_RECEIVER={{ meteor_receiver }}
 NOAA_CROP_TELEMETRY={{ noaa_crop_telemetry|lower }}
 IMAGE_ANNOTATION_LOCATION={{ image_annotation_location }}
+EXTEND_FOR_ANNOTATION={{ extend_for_annotation|lower }}
 GROUND_STATION_LOCATION='{{ ground_station_location }}'
 NOAA_DAY_ENHANCEMENTS='{{ noaa_daytime_enhancements }}'
 NOAA_NIGHT_ENHANCEMENTS='{{ noaa_nighttime_enhancements }}'

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -78,6 +78,9 @@ delete_audio: false
 #   noaa_crop_telemetry - whether to crop the left/right telemetry in image captures
 #   image_annotation_location - where to place the annotation in images - valid options are:
 #        NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast
+#   extend_for_annotation - whether to create a black extension on the north/south location of
+#        the image to place the annotation into (vs. overlaying on the captured data)
+#        (note: this will ONLY work if the image_annotation_location is NOT one of [West|Center|East])
 #   produce_noaa_pristine_image - whether to produce a pristine image (unmodified) for larger
 #        composite-based use cases
 #   produce_noaa_pristine_histogram - whether to produce a histogram of the NOAA pristine image
@@ -98,6 +101,7 @@ flip_meteor_image: true
 produce_spectrogram: true
 noaa_crop_telemetry: false
 image_annotation_location: 'NorthWest'
+extend_for_annotation: false
 produce_noaa_pristine_image: false
 produce_noaa_pristine_histogram: false
 produce_polar_az_el_graph: false

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -79,6 +79,7 @@
     "image_annotation_location": {
       "type": "string"
     },
+    "extend_for_annotation":           { "type": "boolean" },
     "produce_noaa_pristine_image":     { "type": "boolean" },
     "produce_noaa_pristine_histogram": { "type": "boolean" },
     "produce_polar_az_el_graph":       { "type": "boolean" },
@@ -180,6 +181,7 @@
     "produce_spectrogram",
     "noaa_crop_telemetry",
     "image_annotation_location",
+    "extend_for_annotation",
     "produce_noaa_pristine_image",
     "produce_noaa_pristine_histogram",
     "produce_polar_az_el_graph",

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -32,6 +32,7 @@ fi
 # binary helpers
 CONVERT="/usr/bin/convert"
 GMIC="/usr/bin/gmic"
+IDENTIFY="/usr/bin/identify"
 MEDET_ARM="/usr/bin/medet_arm"
 METEOR_DEMOD="/usr/bin/meteor_demod"
 PREDICT="/usr/bin/predict"


### PR DESCRIPTION
Add the ability to specify that the annotation overlay should be above or below the image capture content if specified as one of the Northern or Southern location/gravity types. This will create a black pixelated area above/below the image and place the annotation in that area as opposed to overlaying it on the image capture itself, helping preserve the capture content.