### PR TITLE
Update Schedule Script for TLE Download

### DIFF
--- a/ansible/roles/common/tasks/tools.yml
+++ b/ansible/roles/common/tasks/tools.yml
@@ -57,7 +57,7 @@
     name: schedule passes daily
     minute: 1
     hour: 0
-    job: "{{ noaa_home }}/scripts/schedule.sh"
+    job: "{{ noaa_home }}/scripts/schedule.sh -t"
 
 - name: create scheduling cron job @ reboot
   cron:


### PR DESCRIPTION
Update the schedule script to only download new TLE files when a "-t" switch is provided, which should only occur nightly (to avoid duplicate passes due to small adjustments to the TLE file when the schedule script is run manually or after a reboot).