### PR TITLE
Update Install Script for Missing TLE

### DIFF
--- a/install_and_upgrade.sh
+++ b/install_and_upgrade.sh
@@ -123,7 +123,13 @@ log_running "Updating web content..."
 
 # run a schedule of passes (as opposed to waiting until cron kicks in the evening)
 log_running "Scheduling first passes for imagery..."
-./scripts/schedule.sh
+if [ ! -f $WEATHER_TXT ] || [ ! -f $AMATEUR_TXT ] || [ ! -f $TLE_OUTPUT ]; then
+  log_running "Scheduling with new TLE downloaded data..."
+  ./scripts/schedule.sh -t
+else
+  log_running "Scheduling with existing TLE data (not downloading new)..."
+  ./scripts/schedule.sh
+fi
 log_running "First passes scheduled!"
 
 echo ""

--- a/scripts/schedule.sh
+++ b/scripts/schedule.sh
@@ -7,7 +7,7 @@
 . "$HOME/.noaa-v2.conf"
 . "$NOAA_HOME/scripts/common.sh"
 
-# some constants
+# TLE data files
 WEATHER_TXT="${NOAA_HOME}/tmp/weather.txt"
 AMATEUR_TXT="${NOAA_HOME}/tmp/amateur.txt"
 TLE_OUTPUT="${NOAA_HOME}/tmp/orbit.tle"
@@ -62,6 +62,9 @@ if [ "${update_tle}" == "1" ]; then
   grep "NOAA 18" $WEATHER_TXT -A 2 >> $TLE_OUTPUT
   grep "NOAA 19" $WEATHER_TXT -A 2 >> $TLE_OUTPUT
   grep "METEOR-M 2" $WEATHER_TXT -A 2 >> $TLE_OUTPUT
+elif [ ! -f $WEATHER_TXT ] || [ ! -f $AMATEUR_TXT ] || [ ! -f $TLE_OUTPUT ]; then
+  log "TLE update not specified '-t' but no TLE files present - please re-run with '-t'" "INFO"
+  exit 1
 else
   log "Not updating local copies of TLE files from source" "INFO"
 fi


### PR DESCRIPTION
Update the install script to ensure that the first time the script is run (or if a TLE file is missing), the '-t' flag is passed to the schedule script to download a new TLE file.