### PR TITLE
Add Advanced Scheduling

### DIFF
--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -7,6 +7,7 @@ METEOR_AUDIO_OUTPUT={{ audio_output }}/meteor
 NOAA_ANIMATION_OUTPUT={{ noaa_animation_output }}
 RAMFS_AUDIO={{ ramfs_path }}
 NOAA_LOG={{ log_file }}
+DAYS_TO_SCHEDULE_PASSES={{ days_to_schedule_passes }}
 LAT={{ latitude }}
 LON={{ longitude }}
 TEST_GAIN={{ test_gain }}

--- a/ansible/roles/webserver/templates/Config.php.j2
+++ b/ansible/roles/webserver/templates/Config.php.j2
@@ -12,7 +12,11 @@ class Config {
   # see files in App/Lang directory for available translations
   const LANG = '{{ lang_setting }}';
 
-  # configure time output format on all web pages - note this must follow
+  # configure the date output format for the pass list - note that this must follow
+  # a format that conforms to https://www.php.net/manual/en/datetime.format.php
+  const PASSES_DATE_FORMAT = '{{ web_passes_date_format }}';
+
+  # configure time output format on captures web page - note this must follow
   # a format that conforms to https://www.php.net/manual/en/datetime.format.php
   const DATETIME_FORMAT = '{{ web_datetime_format }}';
 

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -69,6 +69,16 @@ meteor_m2_gain: 7.7
 meteor_m2_sun_min_elevation: 6
 meteor_m2_sat_min_elevation: 30
 
+# how many days to schedule passes - note this MUST be an even integer,
+# and the current day counts as "1" - passes will be scheduled until midnight
+# of the `days_to_schedule_passes` final day
+#
+# NOTE: If you want to set this value LOWER than a previously configured
+#       value, you must run the schedule script manually and pass the '-x' switch
+#       after re-running the ./install_and_upgrade.sh script to align the variables:
+#           ./scripts/schedule.sh -x
+days_to_schedule_passes: 1
+
 # whether audio files should be deleted after images are created
 delete_audio: false
 

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -190,7 +190,9 @@ lang_setting: en
 #   admin_username - username used to access the 'admin' endpoint of the webpanel (WARNING: see 'lock_admin_page' above)
 #   admin_password - password used to access the 'admin' endpoint of the webpanel (WARNING: see 'lock_admin_page' above)
 #                    NOTE: MAKE SURE YOU SET THIS TO SOMETHING REASONABLY COMPLICATED!
-#   web_datetime_format - format to display date and time in the web interface - note that this MUST conform to
+#   web_passes_date_format - format to display the dates in the pass list view - note that this MUST conform to
+#                            https://www.php.net/manual/en/datetime.format.php or else bad things will happen
+#   web_datetime_format - format to display date and time in the web interface for captures - note that this MUST conform to
 #                         https://www.php.net/manual/en/datetime.format.php or else bad things will happen
 web_server_name: raspberry-noaa.localdomain
 enable_non_tls: false
@@ -201,6 +203,7 @@ cert_valid_days: 365
 lock_admin_page: false
 admin_username: 'admin'
 admin_password: 'admin'
+web_passes_date_format: 'm/d/Y'
 web_datetime_format: 'm/d/Y H:i:s'
 
 # log level for output from scripts

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -122,11 +122,12 @@
       "minimum": 1,
       "maximum": 65534
     },
-    "cert_valid_days":     { "type": "number" },
-    "lock_admin_page":     { "type": "boolean" },
-    "admin_username":      { "type": "string" },
-    "admin_password":      { "type": "string" },
-    "web_datetime_format": { "type": "string" },
+    "cert_valid_days":        { "type": "number" },
+    "lock_admin_page":        { "type": "boolean" },
+    "admin_username":         { "type": "string" },
+    "admin_password":         { "type": "string" },
+    "web_passes_date_format": { "type": "string" },
+    "web_datetime_format":    { "type": "string" },
     "log_level": {
       "type": "string",
       "enum": [ "DEBUG", "WARN", "INFO", "ERROR" ]
@@ -223,6 +224,7 @@
     "lock_admin_page",
     "admin_username",
     "admin_password",
+    "web_passes_date_format",
     "web_datetime_format",
     "log_level",
     "enable_satvis",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -72,6 +72,7 @@
       "minimum": 0,
       "maximum": 90
     },
+    "days_to_schedule_passes":         { "type": "number" },
     "delete_audio":                    { "type": "boolean" },
     "flip_meteor_image":               { "type": "boolean" },
     "produce_spectrogram":             { "type": "boolean" },
@@ -183,6 +184,7 @@
     "meteor_m2_gain",
     "meteor_m2_sun_min_elevation",
     "meteor_m2_sat_min_elevation",
+    "days_to_schedule_passes",
     "delete_audio",
     "flip_meteor_image",
     "produce_spectrogram",

--- a/install_and_upgrade.sh
+++ b/install_and_upgrade.sh
@@ -128,7 +128,7 @@ log_running "Updating web content..."
 ) || die "  Something went wrong updating web content - please inspect the logs above"
 
 # run a schedule of passes (as opposed to waiting until cron kicks in the evening)
-log_running "Scheduling first passes for imagery..."
+log_running "Scheduling passes for imagery..."
 if [ ! -f $WEATHER_TXT ] || [ ! -f $AMATEUR_TXT ] || [ ! -f $TLE_OUTPUT ]; then
   log_running "Scheduling with new TLE downloaded data..."
   ./scripts/schedule.sh -t
@@ -136,7 +136,7 @@ else
   log_running "Scheduling with existing TLE data (not downloading new)..."
   ./scripts/schedule.sh
 fi
-log_running "First passes scheduled!"
+log_running "Passes scheduled!"
 
 echo ""
 echo "-------------------------------------------------------------------------------"

--- a/scripts/schedule.sh
+++ b/scripts/schedule.sh
@@ -2,6 +2,13 @@
 #
 # Purpose: High-level scheduling script - schedules all desired satellite
 #          and orbital captures.
+#
+# Parameters:
+#   -t: Update/re-download TLE files
+#   -x: Wipe all existing future scheduled captures and start fresh
+#
+# Example:
+#   ./schedule.sh -t -x
 
 # import common lib and settings
 . "$HOME/.noaa-v2.conf"
@@ -14,11 +21,15 @@ TLE_OUTPUT="${NOAA_HOME}/tmp/orbit.tle"
 
 # check if TLE file should be updated
 update_tle=0
-while getopts ":t" opt; do
+wipe_existing=0
+while getopts ":t:x" opt; do
   case $opt in
     # update TLE files
     t )
       update_tle=1
+      ;;
+    x )
+      wipe_existing=1
       ;;
   esac
 done
@@ -69,35 +80,63 @@ else
   log "Not updating local copies of TLE files from source" "INFO"
 fi
 
-# remove 'at' jobs to make way for new jobs
-log "Clearing existing scheduled 'at' capture jobs..." "INFO"
-for i in $(atq | awk '{print $1}'); do
-  atrm "$i"
-done
+# section to remove all existing scheduled jobs/captures and clear
+# all future database captures, making room for a brand new schedule
+atq_date=""
+if [ "${wipe_existing}" == "1" ]; then
+  # remove 'at' jobs to make way for new jobs
+  log "Clearing existing scheduled 'at' capture jobs..." "INFO"
+  for i in $(atq | awk '{print $1}'); do
+    atrm "$i"
+  done
 
-# remove database passes for remainder of day so they can
-# be re-populated with new records
-cur_ms=$(date +"%s")
-log "Clearing existing passes specified in the database for remainder of the day..." "INFO"
-$SQLITE3 $DB_FILE "DELETE FROM predict_passes WHERE pass_start > $cur_ms;"
+  # remove database passes for remainder of day
+  cur_ms=$(date +"%s")
+  log "Clearing existing passes specified in the database for remainder of the captures..." "INFO"
+  $SQLITE3 $DB_FILE "DELETE FROM predict_passes WHERE pass_start > $cur_ms;"
+else
+  log "Determining latest scheduled capture job date..." "INFO"
+  atq_date=$(atq | sort -k 6n -k 3M -k 4n -k 5 -k 7 -k 1 | awk '{print $3 " " $4 ", " $6}' | tail -1)
+fi
+
+start_time_ms=$(date +"%s")
+last_day=$(($DAYS_TO_SCHEDULE_PASSES - 1))
+end_time_ms=$(date --date="+${last_day} days 23:59:59" +"%s")
+if [ -z "${atq_date}" ]; then
+  log "No passes currently scheduled - scheduling all passes starting now through ${end_time_ms} ms..." "INFO"
+else
+  # calculate current day of last passes and what should be the
+  # latest day of scheduled passes - assume if we've scheduled into
+  # any point of the last day, we're covering all passes already
+  latest_scheduled_ms=$(date --date="${atq_date} 23:59:59" +"%s")
+  future_schedule_ms=$(date --date="+${last_day} days 00:00:00" +"%s")
+
+  if [ "${latest_scheduled_ms}" -ge "${future_schedule_ms}" ]; then
+    log "All passes already scheduled to latest date - nothing to be done" "INFO"
+    exit
+  else
+    start_time_ms=$(($latest_scheduled_ms + 60))
+    log "Scheduling starting at ${start_time_ms} ms through ${end_time_ms} ms..." "INFO"
+  fi
+fi
 
 # create schedules to call respective receive scripts
 log "Scheduling new capture jobs..." "INFO"
 if [ "$NOAA_15_SCHEDULE" == "true" ]; then
   log "Scheduling NOAA 15 captures..." "INFO"
-  $NOAA_HOME/scripts/schedule_captures.sh "NOAA 15" "receive_noaa.sh" $TLE_OUTPUT >> $NOAA_LOG 2>&1
+  $NOAA_HOME/scripts/schedule_captures.sh "NOAA 15" "receive_noaa.sh" $TLE_OUTPUT $start_time_ms $end_time_ms >> $NOAA_LOG 2>&1
 fi
 if [ "$NOAA_18_SCHEDULE" == "true" ]; then
   log "Scheduling NOAA 18 captures..." "INFO"
-  $NOAA_HOME/scripts/schedule_captures.sh "NOAA 18" "receive_noaa.sh" $TLE_OUTPUT >> $NOAA_LOG 2>&1
+  $NOAA_HOME/scripts/schedule_captures.sh "NOAA 18" "receive_noaa.sh" $TLE_OUTPUT $start_time_ms $end_time_ms >> $NOAA_LOG 2>&1
 fi
 if [ "$NOAA_19_SCHEDULE" == "true" ]; then
   log "Scheduling NOAA 19 captures..." "INFO"
-  $NOAA_HOME/scripts/schedule_captures.sh "NOAA 19" "receive_noaa.sh" $TLE_OUTPUT >> $NOAA_LOG 2>&1
+  $NOAA_HOME/scripts/schedule_captures.sh "NOAA 19" "receive_noaa.sh" $TLE_OUTPUT $start_time_ms $end_time_ms >> $NOAA_LOG 2>&1
 fi
 if [ "$METEOR_M2_SCHEDULE" == "true" ]; then
   log "Scheduling Meteor-M 2 captures..." "INFO"
-  $NOAA_HOME/scripts/schedule_captures.sh "METEOR-M 2" "receive_meteor.sh" $TLE_OUTPUT >> $NOAA_LOG 2>&1
+  $NOAA_HOME/scripts/schedule_captures.sh "METEOR-M 2" "receive_meteor.sh" $TLE_OUTPUT $start_time_ms $end_time_ms >> $NOAA_LOG 2>&1
 fi
 log "Done scheduling jobs!" "INFO"
 

--- a/scripts/schedule_captures.sh
+++ b/scripts/schedule_captures.sh
@@ -5,9 +5,11 @@
 #            1. Satellite Name
 #            2. Name of script to call for reception
 #            3. TLE file
+#            4. Start time to predict passes (ms)
+#            5. End time to predict passes (ms)
 #
 # Example:
-#   ./schedule_captures.sh "NOAA 18" "receive_noaa.sh" "weather.tle"
+#   ./schedule_captures.sh "NOAA 18" "receive_noaa.sh" "weather.tle" 1617422399 1617425300
 
 # import common lib and settings
 . "$HOME/.noaa-v2.conf"
@@ -17,6 +19,8 @@
 OBJ_NAME=$1
 RECEIVE_SCRIPT=$2
 TLE_FILE=$3
+START_TIME_MS=$4
+END_TIME_MS=$5
 
 if [ "$OBJ_NAME" == "NOAA 15" ]; then
   SAT_MIN_ELEV=$NOAA_15_SAT_MIN_ELEV
@@ -32,14 +36,15 @@ if [ "$OBJ_NAME" == "METEOR-M 2" ]; then
 fi
 
 # come up with prediction start/end timings for pass
-predict_start=$($PREDICT -t $TLE_FILE -p "${OBJ_NAME}" | head -1)
-predict_end=$($PREDICT   -t $TLE_FILE -p "${OBJ_NAME}" | tail -1)
-max_elev=$($PREDICT      -t $TLE_FILE -p "${OBJ_NAME}" | awk -v max=0 '{if($5>max){max=$5}}END{print max}')
-azimuth_at_max=$($PREDICT   -t $TLE_FILE -p "${OBJ_NAME}" | awk -v max=0 -v az=0 '{if($5>max){max=$5;az=$6}}END{print az}')
+predict_start=$($PREDICT -t $TLE_FILE -p "${OBJ_NAME}" "${START_TIME_MS}" | head -1)
+predict_end=$($PREDICT   -t $TLE_FILE -p "${OBJ_NAME}" "${START_TIME_MS}" | tail -1)
+max_elev=$($PREDICT      -t $TLE_FILE -p "${OBJ_NAME}" "${START_TIME_MS}" | awk -v max=0 '{if($5>max){max=$5}}END{print max}')
+azimuth_at_max=$($PREDICT   -t $TLE_FILE -p "${OBJ_NAME}" "${START_TIME_MS}" | awk -v max=0 -v az=0 '{if($5>max){max=$5;az=$6}}END{print az}')
 end_epoch_time=$(echo "${predict_end}" | cut -d " " -f 1)
 starting_azimuth=$(echo "${predict_start}" | awk '{print $6}')
 
-while [ "$(date --date="@${end_epoch_time}" +%D)" = "$(date +%D)" ]; do
+# get and schedule passes for user-defined days
+while [ "$(date --date="@${end_epoch_time}" +"%s")" -le "${END_TIME_MS}" ]; do
   start_datetime=$(echo "$predict_start" | cut -d " " -f 3-4)
   start_epoch_time=$(echo "$predict_start" | cut -d " " -f 1)
   start_time_seconds=$(echo "$start_datetime" | cut -d " " -f 2 | cut -d ":" -f 3)

--- a/webpanel/App/Views/Admin/passes.html
+++ b/webpanel/App/Views/Admin/passes.html
@@ -43,15 +43,26 @@
       </tr>
     </thead>
     <tbody>
-      {% set now = 'now'|date('H:i:s') %}
+      {% set now = 'now'|date('m/d/y H:i:s') %}
+      {% set cur_date = 'now'|date('m/d/y') %}
+      {% set last_date = 0 %}
+
       {% if pass.list|length <= 0 %}
         <tr>
-          <td colspan="4" class="no-passes">0 {{ lang['passes'] }}</td>
+          <td colspan="7" class="no-passes">0 {{ lang['passes'] }}</td>
         </tr>
       {% else %}
         {% for pass in pass.list %}
           {% set pass_start = pass.pass_start|date('H:i:s') %}
           {% set pass_end = pass.pass_end|date('H:i:s') %}
+          {% set cur_date = pass.pass_start|date('m/d/y') %}
+
+          {% if last_date < cur_date %}
+            <tr class="date-separator">
+              <td colspan="7">{{ cur_date }}</td>
+            </tr>
+            {% set last_date = cur_date %}
+          {% endif %}
 
           <tr{% if pass.is_active == false or pass_end < now %} class="inactive"{% endif %}>
             <td class="capture-select text-center align-middle">

--- a/webpanel/App/Views/Passes/index.html
+++ b/webpanel/App/Views/Passes/index.html
@@ -33,15 +33,26 @@
       </tr>
     </thead>
     <tbody>
-      {% set now = 'now'|date('H:i:s') %}
+      {% set now = 'now'|date('m/d/y H:i:s') %}
+      {% set cur_date = 'now'|date('m/d/y') %}
+      {% set last_date = 0 %}
+
       {% if pass.list|length <= 0 %}
         <tr>
-          <td colspan="4" class="no-passes">0 {{ lang['passes'] }}</td>
+          <td colspan="6" class="no-passes">0 {{ lang['passes'] }}</td>
         </tr>
       {% else %}
         {% for pass in pass.list %}
           {% set pass_start = pass.pass_start|date('H:i:s') %}
           {% set pass_end = pass.pass_end|date('H:i:s') %}
+          {% set cur_date = pass.pass_start|date('m/d/y') %}
+
+          {% if last_date < cur_date %}
+            <tr class="date-separator">
+              <td colspan="6">{{ cur_date }}</td>
+            </tr>
+            {% set last_date = cur_date %}
+          {% endif %}
 
           <tr{% if pass.is_active == false or pass_end < now %} class="inactive"{% endif %}>
             <td{% if prev_pass_end >= pass.pass_start %} class="conflict"{% endif %}>

--- a/webpanel/App/Views/Passes/index.html
+++ b/webpanel/App/Views/Passes/index.html
@@ -49,7 +49,7 @@
 
           {% if last_date < cur_date %}
             <tr class="date-separator">
-              <td colspan="6">{{ cur_date }}</td>
+              <td colspan="6">{{ cur_date|date(constant('Config\\Config::PASSES_DATE_FORMAT')) }}</td>
             </tr>
             {% set last_date = cur_date %}
           {% endif %}

--- a/webpanel/public/assets/css/admin.css
+++ b/webpanel/public/assets/css/admin.css
@@ -14,3 +14,10 @@ table#admin-pass-list tr td.conflict i.conflict-icon {
 table#admin-pass-list tr td {
   vertical-align: middle;
 }
+
+table#admin-pass-list tr.date-separator td {
+  background-color: #cce5ff !important;
+  font-size: .95em;
+  font-weight: bold;
+  text-align: center;
+}

--- a/webpanel/public/assets/css/pass_list.css
+++ b/webpanel/public/assets/css/pass_list.css
@@ -27,6 +27,13 @@ table#passes td.no-passes {
   font-style: italic;
 }
 
+table#passes tr.date-separator td {
+  background-color: #cce5ff !important;
+  font-size: .95em;
+  font-weight: bold;
+  text-align: center;
+}
+
 .flex-container {
   display: flex;
 }


### PR DESCRIPTION
Add the ability to configure how many days you wish to schedule passes for to help with future schedule management/visibility. Note that there are a few changes in this PR:

1. Specifying the number of days you want to schedule for is done via the `days_to_schedule_passes` configuration parameter.
2. The schedule script now has an extra switch `-x` which enables wiping all existing future passes and re-generating the schedule. This is useful if you want to "start over" or if you want to decrease the number of days to schedule for, which requires updating the configuration, re-running the install script, and then running `./schedule.sh -x`.
3. The schedule script now checks for whether you have already scheduled up to/through your configured scheduled days. This allows re-running the script and having it ignore any changes if you're already scheduled far enough out to cover your days. It also allows for "picking up" from where the schedule left off, only scheduling for days that have not yet been scheduled (at the end). This prevents the nightly cron job that runs the schedule from wiping existing scheduled jobs and re-creating them, which helps avoid where a user would delete future passes in favor of others (via the web interface) but then having their deletions re-added by the schedule script.