### PR TITLE
Add a push provider to Matrix

### DIFF
--- a/ansible/roles/common/tasks/dependencies.yml
+++ b/ansible/roles/common/tasks/dependencies.yml
@@ -13,6 +13,7 @@
       - gnuradio
       - gr-osmosdr
       - imagemagick
+      - jq
       - libatlas-base-dev
       - libjpeg9
       - libjpeg9-dev

--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -79,6 +79,7 @@ ENABLE_EMAIL_SCHEDULE_PUSH={{ enable_email_schedule_push|lower }}
 ENABLE_DISCORD_PUSH={{ enable_discord_push|lower }}
 DISCORD_WEBHOOK='{{ discord_webhook_url }}'
 ENABLE_TWITTER_PUSH={{ enable_twitter_push|lower }}
+ENABLE_MATRIX_PUSH={{ enable_matrix_push|lower }}
 NTP_SERVER={{ ntp_server }}
 WEBPANEL_PORT={{ web_port }}
 WEBPANEL_TLS_PORT={{ web_tls_port }}

--- a/config/settings.yml.sample
+++ b/config/settings.yml.sample
@@ -245,10 +245,13 @@ disable_wifi_power_mgmt: false
 #   discord_webhook_url - webhook url for the Discord channel
 #   enable_twitter_push - whether to push images to a Twitter feed
 #     * see docs/twitter_push.md for instructions
+#   enable_matrix_push - whether to push images to a Matrix room
+#     * see docs/matrix_push.md for instructions
 enable_email_push: false
 email_push_address: test@ifttt.com
 enable_email_schedule_push: false
 enable_discord_push: false
 discord_webhook_url: ''
 enable_twitter_push: false
+enable_matrix_push: false
 ...

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -146,7 +146,8 @@
     "enable_email_schedule_push": { "type": "boolean" },
     "enable_discord_push":        { "type": "boolean" },
     "discord_webhook_url":        { "type": "string" },
-    "enable_twitter_push":        { "type": "boolean" }
+    "enable_twitter_push":        { "type": "boolean" },
+    "enable_matrix_push":        { "type": "boolean" }
   },
   "required": [
     "latitude",
@@ -239,6 +240,7 @@
     "enable_email_schedule_push",
     "enable_discord_push",
     "discord_webhook_url",
-    "enable_twitter_push"
+    "enable_twitter_push",
+    "enable_matrix_push"
   ]
 }

--- a/docs/matrix_push.md
+++ b/docs/matrix_push.md
@@ -1,0 +1,50 @@
+![Raspberry NOAA](../assets/header_1600_v2.png)
+
+In `config/settings.yml`, setting `enable_matrix_push: true` will enable pushing all captured, processed
+images to a Matrix room. See below headings for the sequence of steps required to enable this functionality.
+
+## Enable Matrix Push for raspberry-noaa-v2
+
+First, update your `config/settings.yml` file to set `enable_matrix_push: true`.
+
+Finally, re-run the `./install_and_upgrade.sh` script to propagate the settings and install a sample/template
+`~pi/.matrix.conf` configuration file.
+
+## Matrix Configuration Requirements
+
+In order to configure Matrix pushing, you will need to have a matrix account.
+You will need to know three things to configure the notifications:
+
+* The alias or id of your room.
+* The address of your matrix server.
+* An access token.
+
+The alias you can get from room settings for an existing room, or set one when creating the room.
+The address and the access token you can get from the "Help and About" settings in Element web/desktop if you don't already know them.
+
+Once you have these add them to a file named `~pi/.matrix.conf` so it looks like this:
+
+```
+MATRIX_HOMESERVER="https://matrix.org"
+MATRIX_ROOM="#weather:matrix.org"
+MATRIX_ACCESS_TOKEN="..."
+```
+
+## Testing (Optional)
+
+If you want to run a manual test to test the matrix configuration, you can run a quick test
+from the command line and pass an actual image file (or many) to the command like so:
+
+```bash
+./scripts/push_processors/push_matrix.sh "test annotation" \
+                                         "/srv/images/NOAA-18-20210212-091356-MCIR.jpg" \
+                                         "/srv/images/NOAA-19-20210311-060645-ZA.jpg"   \
+                                         "/srv/images/NOAA-19-20210311-060645-spectrogram.png"
+```
+
+If all goes well and the image paths passed are files that actually exist, you should see new posts in your matrix room!
+
+## Profit
+
+Once the above have been performed, simply wait until your next capture occurs and you should then see posts with
+images show up in your room.

--- a/scripts/push_processors/push_matrix.sh
+++ b/scripts/push_processors/push_matrix.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Purpose: Send image and message to a matrix room
+#
+# Input parameters:
+#   1. Description to be sent as a normal message after all the images
+#   2+. List of image paths to send (can be 1-many)
+#
+# Example:
+#   ./scripts/push_processors/push_matrix.sh "test annotation" "/srv/images/NOAA-18-20210212-091356-MCIR.jpg" \
+#                                                              "/srv/images/NOAA-18-20210212-091356-HVC.jpg" \
+#                                                              "/srv/images/NOAA-18-20210212-091356-MCIR-precip.jpg"
+
+# import common lib and settings
+. "$HOME/.noaa-v2.conf"
+. "$NOAA_HOME/scripts/common.sh"
+. "$HOME/.matrix.conf"
+
+# input params
+MESSAGE=$1
+shift
+IMAGES=$@
+
+# check that matrix is configured
+if [ -z "${MATRIX_ACCESS_TOKEN}" ]; then
+    log "No matrix access token defined check your ~/.matrix.conf file" "ERROR"
+    exit 1
+fi
+
+if [ -z "${MATRIX_HOMESERVER}" ]; then
+    log "No matrix homeserver URL defined check your ~/.matrix.conf file" "ERROR"
+    exit 1
+fi
+
+if [ -z "${MATRIX_ROOM}" ]; then
+    log "No matrix room address defined check your ~/.matrix.conf file" "ERROR"
+    exit 1
+fi
+
+roomid=$MATRIX_ROOM
+
+# Convert Alias to ID
+if [[ $roomid == \#* ]] ;
+then
+    encalias=$(jq -rn --arg u "$roomid" '$u|@uri')
+    roomid=$(curl -X GET -H "Content-Type: application/json" "$HOMESERVER/_matrix/client/r0/directory/room/${encalias}" | jq -r .room_id)
+fi
+
+for imagefile in $IMAGES; do
+    if [ ! -f "${imagefile}" ]; then
+        log "Could not find image ${imagefile} to post to Matrix - ignoring" "WARN"
+    else
+        # Extract filename
+        filename=$(basename $imagefile)
+
+        # Extract Content type
+        content_type=$(file -b --mime-type $imagefile)
+
+        # Upload image, extract mxc URL
+        uri=$(curl -X POST --data-binary "@${imagefile}" -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: ${content_type}" "$HOMESERVER/_matrix/media/r0/upload?filename=${filename}" | jq -r .content_uri)
+
+        # Send message with image
+        curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Content-Type: application/json" -X PUT -d "{ \"body\": \"${filename}\", \"msgtype\": \"m.image\", \"url\": \"${uri}\" }" "$HOMESERVER/_matrix/client/r0/rooms/${roomid}/send/m.room.message/$(date +%s)"
+    fi
+done
+
+curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Content-Type: application/json" -X PUT -d "{ \"body\": \"${MESSAGE}\" }" "$HOMESERVER/_matrix/client/r0/rooms/${roomid}/send/m.room.message/$(date +%s)"

--- a/scripts/push_processors/push_matrix.sh
+++ b/scripts/push_processors/push_matrix.sh
@@ -56,10 +56,12 @@ for imagefile in $IMAGES; do
         uri=$(curl -X POST -H "Authorization: Bearer $MATRIX_ACCESS_TOKEN" -H "Content-Type: ${content_type}" --data-binary "@${imagefile}" "$MATRIX_HOMESERVER/_matrix/media/r0/upload?filename=${filename}" | jq -r .content_uri)
 
         # Send message with image
-        curl -H "Authorization: Bearer $MATRIX_ACCESS_TOKEN" -H "Content-Type: ${content_type}" -X PUT -d "{ \"body\": \"${filename}\", \"msgtype\": \"m.image\", \"url\": \"${uri}\" }" "$MATRIX_HOMESERVER/_matrix/client/r0/rooms/${roomid}/send/m.room.message/$(date +%s)"
+	image_log=$(curl -H "Authorization: Bearer $MATRIX_ACCESS_TOKEN" -H "Content-Type: ${content_type}" -X PUT -d "{ \"body\": \"${filename}\", \"msgtype\": \"m.image\", \"url\": \"${uri}\" }" "$MATRIX_HOMESERVER/_matrix/client/r0/rooms/${roomid}/send/m.room.message/$(date +%s)" 2>&1)
+	log "${image_log}" "INFO"
     fi
 done
 
 sleep 1
 
-curl -H "Authorization: Bearer $MATRIX_ACCESS_TOKEN" -H "Content-Type: ${content_type}" -X PUT -d "{ \"body\": \"${MESSAGE}\", \"msgtype\": \"m.text\" }" "$MATRIX_HOMESERVER/_matrix/client/r0/rooms/${roomid}/send/m.room.message/$(date +%s)"
+message_log=$(curl -H "Authorization: Bearer $MATRIX_ACCESS_TOKEN" -H "Content-Type: ${content_type}" -X PUT -d "{ \"body\": \"${MESSAGE}\", \"msgtype\": \"m.text\" }" "$MATRIX_HOMESERVER/_matrix/client/r0/rooms/${roomid}/send/m.room.message/$(date +%s)" 2?&1)
+log "${message_log}" "INFO"

--- a/scripts/receive_meteor.sh
+++ b/scripts/receive_meteor.sh
@@ -409,6 +409,24 @@ if [ "${ENABLE_TWITTER_PUSH}" == "true" ]; then
   ${PUSH_PROC_DIR}/push_twitter.sh "${twitter_push_annotation}" $push_file_list
 fi
 
+# handle matrix pushing if enabled
+if [ "${ENABLE_MATRIX_PUSH}" == "true" ]; then
+    # create push annotation specific to matrix
+    # note this is NOT the annotation on the image, which is driven by the config/annotation/annotation.html.j2 file
+    matrix_push_annotation=""
+    if [ "${GROUND_STATION_LOCATION}" != "" ]; then
+        matrix_push_annotation="Ground Station: ${GROUND_STATION_LOCATION} "
+    fi
+    matrix_push_annotation="${matrix_push_annotation}${SAT_NAME} ${capture_start}"
+    matrix_push_annotation="${matrix_push_annotation} Max Elev: ${SAT_MAX_ELEVATION}° ${PASS_SIDE}"
+    matrix_push_annotation="${matrix_push_annotation} Sun Elevation: ${SUN_ELEV}°"
+    matrix_push_annotation="${matrix_push_annotation} Gain: ${gain}"
+    matrix_push_annotation="${matrix_push_annotation} | ${PASS_DIRECTION}"
+
+    log "Pushing image enhancements to Matrix" "INFO"
+    ${PUSH_PROC_DIR}/push_matrix.sh "${matrix_push_annotation}" $push_file_list
+fi
+
 # calculate and report total time for capture
 TIMER_END=$(date '+%s')
 DIFF=$(($TIMER_END - $TIMER_START))

--- a/scripts/receive_noaa.sh
+++ b/scripts/receive_noaa.sh
@@ -299,6 +299,24 @@ if [ "${ENABLE_TWITTER_PUSH}" == "true" ]; then
   ${PUSH_PROC_DIR}/push_twitter.sh "${twitter_push_annotation}" $push_file_list
 fi
 
+# handle matrix pushing if enabled
+if [ "${ENABLE_MATRIX_PUSH}" == "true" ]; then
+    # create push annotation specific to matrix
+    # note this is NOT the annotation on the image, which is driven by the config/annotation/annotation.html.j2 file
+    matrix_push_annotation=""
+    if [ "${GROUND_STATION_LOCATION}" != "" ]; then
+        matrix_push_annotation="Ground Station: ${GROUND_STATION_LOCATION} "
+    fi
+    matrix_push_annotation="${matrix_push_annotation}${SAT_NAME} ${capture_start}"
+    matrix_push_annotation="${matrix_push_annotation} Max Elev: ${SAT_MAX_ELEVATION}° ${PASS_SIDE}"
+    matrix_push_annotation="${matrix_push_annotation} Sun Elevation: ${SUN_ELEV}°"
+    matrix_push_annotation="${matrix_push_annotation} Gain: ${gain}"
+    matrix_push_annotation="${matrix_push_annotation} | ${PASS_DIRECTION}"
+
+    log "Pushing image enhancements to Matrix" "INFO"
+    ${PUSH_PROC_DIR}/push_matrix.sh "${matrix_push_annotation}" $push_file_list
+fi
+
 rm "${NOAA_HOME}/tmp/map/${FILENAME_BASE}-map.png"
 
 # store enhancements if there was at least 1 good image created


### PR DESCRIPTION
This adds the ability to push to [Matrix](matrix.org) rooms, it sends all the images and the summary like the twitter client, although it probably could post the images in the main loop with the other providers, but would need to send the summary at the end.

I hope this looks good, I didn't end up adding it to the main config file as I thought it would be better to follow the other services, but I would be happy to change it.