### PR TITLE
script link incorrect

### DIFF
--- a/docs/pruning.md
+++ b/docs/pruning.md
@@ -15,7 +15,7 @@ configured to run nightly at midnight using this script:
 
 ```bash
 # prune oldest n captures
-cat <(crontab -l) <(echo "1 0 * * * /home/pi/raspberry-noaa-v2/scripts/prune_oldest.sh") | crontab -
+cat <(crontab -l) <(echo "1 0 * * * /home/pi/raspberry-noaa-v2/scripts/prune_scripts/prune_oldest.sh") | crontab -
 ```
 
 ## Prune Captures Older Than n Days
@@ -26,5 +26,5 @@ that is configured to run nightly at midnight using this script:
 
 ```bash
 # prune captures older than n days
-cat <(crontab -l) <(echo "1 0 * * * /home/pi/raspberry-noaa-v2/scripts/prune_older_than.sh") | crontab -
+cat <(crontab -l) <(echo "1 0 * * * /home/pi/raspberry-noaa-v2/scripts/prune_scripts/prune_older_than.sh") | crontab -
 ```


### PR DESCRIPTION
The pruning scripts are put in an extra directory (/prune_scripts) which is correctly mentioned in the description, but incorrect in the code.
If you copy-paste the code for the cronjob like I did, you don't see the error and only after a while you notice pruning isn't executed ;-)