### PR TITLE
FLIP capture only if PASS_DIRECTION is Northbound

### DIFF
--- a/scripts/receive_meteor.sh
+++ b/scripts/receive_meteor.sh
@@ -61,8 +61,9 @@ else
 fi
 
 FLIP=""
-if [ "$FLIP_METEOR_IMG" == "true" ]; then
-  log "I'll flip this image pass because FLIP_METEOR_IMG is set to true" "INFO"
+log "Direction $PASS_DIRECTION" "INFO"
+if [ "$PASS_DIRECTION" == "Northbound" ] && [ "$FLIP_METEOR_IMG" == "true" ]; then
+  log "I'll flip this image pass because FLIP_METEOR_IMG is set to true and PASS_DIRECTION is Northbound" "INFO"
   FLIP="-rotate 180"
 fi
 
@@ -187,6 +188,7 @@ if [ "$METEOR_RECEIVER" == "rtl_fm" ]; then
     else
       log "I got a successful ${FILENAME_BASE}.dec file. Creating false color image" "INFO"
       ${IMAGE_PROC_DIR}/meteor_false_color_decode.sh "${AUDIO_FILE_BASE}.dec" "${IMAGE_FILE_BASE}-122" >> $NOAA_LOG 2>&1
+	  $CONVERT $FLIP "${IMAGE_FILE_BASE}-122.bmp" "${IMAGE_FILE_BASE}-122.bmp" >> $NOAA_LOG 2>&1
     fi
 
     log "Rectifying image to adjust aspect ratio" "INFO"


### PR DESCRIPTION
FLIP, if enabled, was used on any pass with a low SUN_ELEV.

This modification flips the capture :
- indifferently of the SUN_ELEV
- only if the PASS_DIRECTION is Northbound
