### PR TITLE
Update receive_meteor.sh to use available memory rather than free memory

### DIFF
--- a/scripts/receive_meteor.sh
+++ b/scripts/receive_meteor.sh
@@ -48,7 +48,7 @@ IMAGE_FILE_BASE="${IMAGE_OUTPUT}/${FILENAME_BASE}"
 IMAGE_THUMB_BASE="${IMAGE_OUTPUT}/thumb/${FILENAME_BASE}"
 
 # check if there is enough free memory to store pass on RAM
-FREE_MEMORY=$(free -m | grep Mem | awk '{print $4}')
+FREE_MEMORY=$(free -m | grep Mem | awk '{print $7}')
 if [ "$FREE_MEMORY" -lt $METEOR_M2_MEMORY_TRESHOLD ]; then
   log "The system doesn't have enough space to store a Meteor pass on RAM" "INFO"
   log "Free : ${FREE_MEMORY} ; Required : ${METEOR_M2_MEMORY_TRESHOLD}" "INFO"


### PR DESCRIPTION
On a Raspberry Pi 2B with little memory in use, I was surprised to receive the following error message:

> The system doesn't have enough space to store a Meteor pass on RAM

The threshold is set in `settings.yml` as `meteor_m2_memory_threshold: 600` (MB).

The test is performed in `scripts/receive_meteor.sh`, using the value in the fourth column (`free`). I have adjusted this to use the seventh column, `available`. 

Free memory excludes memory which the kernel is using for caching and buffers to make the system faster.
The kernel will release non-essential memory used for cache and buffers to userspace processes.
The 'available' memory value is an estimate of the total available to userspace processes.

Tested on Raspberry Pi 2B. Log:

```
06-10-2021 08:25 /home/pi/raspberry-noaa-v2/scripts/receive_meteor.sh INFO : Original free memory (free): 482
06-10-2021 08:25 /home/pi/raspberry-noaa-v2/scripts/receive_meteor.sh INFO : Modified free memory (available): 798
06-10-2021 08:25 /home/pi/raspberry-noaa-v2/scripts/receive_meteor.sh INFO : The system have enough space to store a Meteor pass on RAM
06-10-2021 08:25 /home/pi/raspberry-noaa-v2/scripts/receive_meteor.sh INFO : Free : 798 ; Required : 600
06-10-2021 08:25 /home/pi/raspberry-noaa-v2/scripts/receive_meteor.sh INFO : Direction Southbound
06-10-2021 08:25 /home/pi/raspberry-noaa-v2/scripts/receive_meteor.sh INFO : Starting rtl_fm record
INFO : Recording at 137.1000 MHz...
06-10-2021 08:25 /home/pi/raspberry-noaa-v2/scripts/audio_processors/meteor_record_rtl_fm.sh INFO : Recording at 137.1000 MHz...
Found 1 device(s):
  0:  Realtek, RTL2838UHIDIR, SN: 00000001

Using device 0: Generic RTL2832U OEM
Found Rafael Micro R820T tuner
Tuner gain set to automatic.
activated bias-T on GPIO PIN 0
Tuner error set to 3 ppm.
Tuned to 137388000 Hz.
Oversampling input by: 4x.
Oversampling output by: 1x.
Buffer size: 7.11ms
Allocating 15 zero-copy buffers
Sampling at 1152000 S/s.
Output at 288000 Hz.
06-10-2021 08:33 /home/pi/raspberry-noaa-v2/scripts/receive_noaa.sh ERROR : There is an existing rtl_fm instance running, I quit
Signal caught, exiting!

User cancel, exiting...
06-10-2021 08:41 /home/pi/raspberry-noaa-v2/scripts/receive_meteor.sh INFO : Demodulation in progress (QPSK)
Input: /var/ramfs/METEOR-M-2-20211006-082547.wav, output: /home/pi/raspberry-noaa-v2/tmp/meteor/METEOR-M-2-20211006-082547.qpsk
Demodulator initialized

(  0.0%) Carrier:    +0.0 Hz, Symbol rate: 72000.0 Hz, Locked: No
(  1.5%) Carrier: +2801.3 Hz, Symbol rate: 72017.5 Hz, Locked: Yes
(  3.1%) Carrier: +2794.7 Hz, Symbol rate: 72017.4 Hz, Locked: Yes
(  4.6%) Carrier: -3320.9 Hz, Symbol rate: 72017.5 Hz, Locked: No
```