### PR TITLE
Update logged stats in receive_meteor.sh to include available memory.

### DIFF
--- a/scripts/receive_meteor.sh
+++ b/scripts/receive_meteor.sh
@@ -161,8 +161,9 @@ if [ "$METEOR_RECEIVER" == "rtl_fm" ]; then
 
   # how are we about memory usage at this point ?
   FREE_MEMORY=$(free -m | grep Mem | awk '{print $4}')
+  AVAILABLE_MEMORY=$(free -m | grep Mem | awk '{print $7}')
   RAMFS_USAGE=$(du -sh ${RAMFS_AUDIO} | awk '{print $1}')
-  log "Free memory : ${FREE_MEMORY} ; Total RAMFS usage : ${RAMFS_USAGE}" "INFO"
+  log "Free memory : ${FREE_MEMORY} ; Available memory : ${AVAILABLE_MEMORY} ; Total RAMFS usage : ${RAMFS_USAGE}" "INFO"
 
   if [ "$DELETE_AUDIO" = true ]; then
     log "Deleting audio files" "INFO"


### PR DESCRIPTION
Whilst reviewing the Meteor log, I noticed another place where free memory is logged. It seemed sensible to update this to include the amount of available memory as well. 

Tested on my rPi 2B. Line appears as expected in the log.