### PR TITLE
Add libsox-fmt-mp3 to dependencies

### DIFF
--- a/ansible/roles/common/tasks/dependencies.yml
+++ b/ansible/roles/common/tasks/dependencies.yml
@@ -19,6 +19,7 @@
       - libjpeg9-dev
       - libncurses5-dev
       - libncursesw5-dev
+      - libsox-fmt-mp3
       - libusb-1.0-0
       - libusb-1.0-0-dev
       - libxft-dev


### PR DESCRIPTION
Hope I'm not missing a step here by using the web interface to open this...

I added libsox-fmt-mp3 to the Ansible `dependencies.yml` task. I did a quick search to see if anyone else was having my issue, and came across [this thread](https://github.com/jekhokie/raspberry-noaa-v2/discussions/405) (here's hoping markdown works). Without this library installed, I get the following error when attempting to use `rtl_tcp` or the testing scripts:

` sox FAIL formats: no handler for given file type 'mp3'`

This occurred in my trial run of raspberry-noaa-v1 as well, (on a standard Pi4 Raspbian install via the Raspi Imager and a Nooelec SMART SDR) before I discovered this project. I figured it wouldn't hurt to add to save a few steps of troubleshooting for others.

Let me know if I can provide any more details!