### PR TITLE
Create the MeteorDemod Directory before file creation

### DIFF
--- a/ansible/roles/common/tasks/configs.yml
+++ b/ansible/roles/common/tasks/configs.yml
@@ -30,7 +30,15 @@
     owner: pi
     group: pi
     mode: 0644
-    
+
+- name: MeteorDemod directory
+  file:
+    path: ~pi/.config/meteordemod
+    state: directory
+    owner: pi
+    group: pi
+    mode: 0755
+
 - name: MeteorDemod config settings.ini file
   template:
     src: settings.ini.j2


### PR DESCRIPTION
On a fresh pull of the branch this folder doesn't appear to get created so the `./install_and_upgrade.sh` fails with the following error;

`fatal: [localhost]: FAILED! => {"changed": false, "checksum": "619d72c5665c1b1d6880d8f752cb4b16f2188b61", "msg": "Destination directory /home/pi/.config/meteordemod does not exist"}`

This PR simply adds the creation of the directory in before attempting to copy the template file out to it after which the run succeeds without error.