### PR TITLE
Stop using pip to install python dependencies

### DIFF
--- a/ansible/roles/common/tasks/dependencies.yml
+++ b/ansible/roles/common/tasks/dependencies.yml
@@ -27,7 +27,16 @@
       - libxft2
       - predict
       - python3-pip
-      - python-setuptools
+      - python3-setuptools
+      - python3-idna
+      - python3-jsonschema
+      - python3-matplotlib
+      - python3-numpy
+      - python3-pil # this is really pillow
+      - python3-yaml
+      - python3-requests
+      - python3-urllib3
+      - python3-ephem
       - socat
       - sox
       - sqlite3

--- a/install_and_upgrade.sh
+++ b/install_and_upgrade.sh
@@ -41,27 +41,22 @@ if [ -f /etc/modprobe.d/rtlsdr.conf ]; then
   install_type='upgrade'
 fi
 
-log_running "Checking for python3-pip..."
-dpkg -l python3-pip 2>&1 >/dev/null
-if [ $? -eq 0 ]; then
-  log_done "  python3-pip already installed!"
-else
-  log_running "  python3-pip not yet installed - installing..."
-  sudo apt-get -y install python3-pip
+# Install the dependancies for the check settings script, everything else is installed by ansible
+for package in python3-yaml python3-jsonschema; do
+  log_running "Checking for $package..."
+  dpkg -l $package 2>&1 >/dev/null
   if [ $? -eq 0 ]; then
-    log_done "    python3-pip successfully installed!"
+    log_done "  $package already installed!"
   else
-    die "    Could not install python3-pip - please check the logs above"
+    log_running "  $package not yet installed - installing..."
+    sudo apt-get -y install $package
+    if [ $? -eq 0 ]; then
+      log_done "    $package successfully installed!"
+    else
+      die "    Could not install $package - please check the logs above"
+    fi
   fi
-fi
-
-log_running "Installing Python dependencies..."
-sudo python3 -m pip install -r $HOME/raspberry-noaa-v2/requirements.txt
-if [ $? -eq 0 ]; then
-  log_done "  Successfully aligned required Python packages!"
-else
-  die "  Could not install dependent Python packages - please check the logs above"
-fi
+done
 
 log_running "Checking configuration files..."
 python3 scripts/tools/validate_yaml.py config/settings.yml config/settings_schema.json


### PR DESCRIPTION
This is an attempt to fix #507 but I haven't had time to test it.