### PR TITLE
stop services during satellite recording and image processing

### DIFF
--- a/ansible/roles/common/templates/noaa-v2.conf.j2
+++ b/ansible/roles/common/templates/noaa-v2.conf.j2
@@ -107,3 +107,5 @@ WEB_SERVER_NAME={{ web_server_name }}
 ENABLE_SATVIS={{ enable_satvis|lower }}
 ENABLE_TLS={{ enable_tls|lower }}
 ENABLE_NON_TLS={{ enable_non_tls|lower }}
+PAUSE_SERVICES={{ pause_services }}
+PAUSE_SERVICES_RESTART_IMMEDIATELY={{ pause_services_restart_immediately|lower }}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -287,4 +287,12 @@ slack_push_url: ''
 slack_push_to: ''
 slack_link: 'https://XXXX/captures/listImages'
 enable_matrix_push: false
+
+# To save RAM or maybe when using the same SDR for other services, outside NOAA/Meteor passes, 
+# we can stop certain services (separated by comma) before recording starts.
+# These services will be restarted, defined by 'pause_services_restart_immediately':
+# - true : immediately after recording, before image processing starts
+# - false: at the end, when all image processing is done
+pause_services: ''
+pause_services_restart_immediately: true
 ...

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -180,6 +180,8 @@
       "type": "string",
       "required": "false"
     },
+    "pause_services":             { "type": "string" },
+    "pause_services_restart_immediately": { "type": "boolean" },
     "enable_email_schedule_push": { "type": "boolean" },
     "enable_discord_push":        { "type": "boolean" },
     "discord_noaa_webhook_url":        { "type": "string" },
@@ -285,6 +287,8 @@
     "delete_oldest_n",
     "delete_older_than_n",
     "disable_wifi_power_mgmt",
+    "pause_services",
+    "pause_services_restart_immediately",
     "enable_email_push",
     "email_push_address",
     "enable_email_schedule_push",

--- a/scripts/receive_noaa.sh
+++ b/scripts/receive_noaa.sh
@@ -70,6 +70,12 @@ AUDIO_FILE_BASE="${NOAA_AUDIO_OUTPUT}/${FILENAME_BASE}"
 IMAGE_FILE_BASE="${IMAGE_OUTPUT}/${FILENAME_BASE}"
 IMAGE_THUMB_BASE="${IMAGE_OUTPUT}/thumb/${FILENAME_BASE}"
 
+# if there are services we have to stop during recording, we have to stop them now
+for svc in ${PAUSE_SERVICES}; do
+  log "Stopping service $svc" "INFO"
+  sudo service $svc stop
+done
+
 # check if there is enough free memory to store pass on RAM
 FREE_MEMORY=$(free -m | grep Mem | awk '{print $7}')
 if [ "$FREE_MEMORY" -lt $NOAA_MEMORY_THRESHOLD ]; then
@@ -183,6 +189,16 @@ fi
 
 # wait for files to close
 sleep 2
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+# if there are services we have to stop during recording, we can restart them now, if they have to start immediately after recording / capturing
+if [[ "${PAUSE_SERVICES_RESTART_IMMEDIATELY}" == "true" ]]; then
+  for svc in ${PAUSE_SERVICES}; do
+    log "Starting service (immediately after recording) $svc" "INFO"
+    sudo service $svc start
+  done
+fi
 
 #---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -436,6 +452,18 @@ else
     # If no matching images are found, there is no need to push images
     log "No images found - not pushing anywhere" "INFO"
 fi
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+# if there are services we have to stop during recording, we can restart them now, if they have to start at the end of processing
+if [[ "${PAUSE_SERVICES_RESTART_IMMEDIATELY}" == "false" ]]; then
+  for svc in ${PAUSE_SERVICES}; do
+    log "Starting service (at the end of processing)  $svc" "INFO"
+    sudo service $svc start
+  done
+fi
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 # calculate and report total time for capture
 TIMER_END=$(date '+%s')


### PR DESCRIPTION
 To save RAM or maybe when using the same SDR for other services, outside NOAA/Meteor passes, 
 we can stop certain services (separated by comma) before recording starts.
 These services will be restarted, defined by 'pause_services_restart_immediately':
 - true : immediately after recording, before image processing starts
 - false: at the end, when all image processing is done