### PR TITLE
Add toggle for coronal mass GIFs

### DIFF
--- a/ansible/roles/webserver/templates/Config.php.j2
+++ b/ansible/roles/webserver/templates/Config.php.j2
@@ -33,6 +33,10 @@ class Config {
   # whether to enable satvis visualization
   const ENABLE_SATVIS = '{{ enable_satvis|lower }}';
 
+  # whether to enable coronal mass ejetion GIFs from nasa
+  # warning: high data usage!
+  const ENABLE_CORONAL_GIF = '{{ enable_coronal|lower }}';
+
   # whether to enable image video
   const ENABLE_ANIMATION = '{{ enable_animation|lower }}';
   const ANIMATION_VIDEO_FILE = '{{ noaa_animation_output }}';

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -256,6 +256,12 @@ log_level: DEBUG
 # the processing and space requirements
 enable_satvis: true
 
+
+# whether to enable the "Coronal mass ejection activity" display
+# in the passes view - note that the GIFs can be ~70 MiB and not cached
+# thus they slow down the page & can lead to quite big data usage
+enable_coronal: false
+
 # whether to enable the image video in the passes view - note that this
 # is by default disabled on "extra-small" devices such as phones due
 # to the processing and space requirements

--- a/webpanel/App/Views/Passes/index.html
+++ b/webpanel/App/Views/Passes/index.html
@@ -111,7 +111,7 @@
       {% endif %}
     </tbody>
   </table>
-
+  {% if constant('Config\\Config::ENABLE_CORONAL_GIF') == 'true' %}
   <br>
   <center>
   <h1>Coronal Mass Ejection Activity</h1>
@@ -120,6 +120,7 @@
   <img src="https://sohowww.nascom.nasa.gov/data/LATEST/current_c3.gif" height=300 style="margin-right=2em; margin-bottom:2em;">
   <img src="https://stereo.gsfc.nasa.gov/beacon/latest_512/ahead_cor2_latest.jpg" height=300 style="margin-right=2em; margin-bottom:2em;">
   </center>
+  {% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
We noticed that these GIFs consume quite a lot of data, so I added a toggle for them