### PR TITLE
Update core.yml - Simply getting OS Release

### DIFF
--- a/ansible/core.yml
+++ b/ansible/core.yml
@@ -5,7 +5,7 @@
   gather_facts: no
   pre_tasks:
     - name: get os release
-      shell: grep -E "^deb http://raspbian.raspberry.org/raspbian|^deb http://raspbian.raspberrypi.org/raspbian|^deb http://deb.debian.org/debian|^deb https://deb.debian.org/debian" /etc/apt/sources.list /etc/apt/sources.list.d/official-package-repositories.list 2> /dev/null | head -n 1 | awk '{print $3}'
+      shell: cat /etc/os-release | grep -E "^DEBIAN_CODENAME|^VERSION_CODENAME" | awk -F"=" '{print $NF}' | sort | head -1
       register: raspbian_version
       check_mode: no
       changed_when: no


### PR DESCRIPTION
Update core.yml - Simply getting OS Release 

Goal was to work on as many as Debian Distro's as possible even if they are using local repo's