### PR TITLE
Update README.md - Add 5th Prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ consistent time and language handling.
 4. It's not recommended to use the default user "pi" and the default password "raspberry". While it is not
 recommended that you expose a Pi instance to the public internet for access (unless you have a VERY strict process about security
 patching, and even then it would still be questionable), updating your Pi user password is a decent first step for security.
+5. When you perform the operating system install, please ensure the account name you choose for installing the RN2 software under is 9 characters or less.
+This character limit is due to a known constraint with predict scheduling tool.
 
 ## Install
 


### PR DESCRIPTION
5. When you perform the operating system install, please ensure the account name you choose for installing the RN2 software under is 9 characters or less. This character limit is due to a known constraint with predict scheduling tool.