### PR TITLE
Update rn2_uninstall.sh - Fixing an oddity when service is recreated after being disabled during uninstall

### DIFF
--- a/ansible/roles/common/files/rn2_uninstall.sh
+++ b/ansible/roles/common/files/rn2_uninstall.sh
@@ -87,8 +87,12 @@ remove_services() {
   do
    
     loggit "INFO" "Stopping and removing ${svc} service"
-    sudo sudo systemctl stop ${svc}
-    sudo sudo systemctl disable ${svc}
+    sudo systemctl stop ${svc}
+	  # Disable causes it to remain disabled even after the service is removed and reinstalled by Ansible 
+	  # this is because disable removes /etc/systemd/system/multi-user.target.wants/nginx.service and is not added back when Ansible installs it. 
+	  # If Ansible had issued an systemctl enable nsinx enable it would worked. 
+	  # Commenting out the disable command because disabling the service is no impact since it will be removed when removing packages 
+    # sudo systemctl disable ${svc}
      
   done
 


### PR DESCRIPTION
Commenting out systemctl disable service because disable causes it to remain disabled even after the service is removed and reinstalled by Ansible 
	
Commenting out the disable command has no impact since it will be removed when removing packages