### PR TITLE
Add Multiple Delete on Captures

### DIFF
--- a/webpanel/App/Controllers/AdminController.php
+++ b/webpanel/App/Controllers/AdminController.php
@@ -5,14 +5,18 @@ namespace App\Controllers;
 use Lib\View;
 use Config\Config;
 
-class AdminController extends \Lib\Controller {
+class AdminController extends \Lib\Controller
+{
   # perform authentication prior to access any admin endpoint
   # NOTE: This is a CHEAP method of security and not recommended as
   #       "sufficient" to enable exposing things on the public internet.
-  protected function before() {
+  protected function before()
+  {
     if (Config::LOCK_ADMIN == "true") {
-      if (!isset($_SERVER['PHP_AUTH_USER']) ||
-          ($_SERVER['PHP_AUTH_USER'] != Config::ADMIN_USER || $_SERVER['PHP_AUTH_PW'] != Config::ADMIN_PASS)) {
+      if (
+        !isset($_SERVER['PHP_AUTH_USER']) ||
+        ($_SERVER['PHP_AUTH_USER'] != Config::ADMIN_USER || $_SERVER['PHP_AUTH_PW'] != Config::ADMIN_PASS)
+      ) {
         header('WWW-Authenticate: Basic realm="raspberry-noaa-v2"');
         header('HTTP/1.0 401 Unauthorized');
         echo 'Auth required';
@@ -21,17 +25,21 @@ class AdminController extends \Lib\Controller {
     }
   }
 
-  public function passesAction($args) {
+  public function passesAction($args)
+  {
     $pass = $this->loadModel('Pass');
     $pass->getActiveList();
-    $args = array_merge($args, array('pass' => $pass,
-                                     'admin_action' => 'passes'));
+    $args = array_merge($args, array(
+      'pass' => $pass,
+      'admin_action' => 'passes'
+    ));
     View::renderTemplate('Admin/passes.html', $args);
   }
 
   # TODO: This is not very DRY between this and the above function - do
   #       something about this in the future
-  public function deletePassAction($args) {
+  public function deletePassAction($args)
+  {
     $lang = include(__DIR__ . '/../Lang/' . Config::LANG . '.php');
     $pass = $this->loadModel('Pass');
 
@@ -43,7 +51,7 @@ class AdminController extends \Lib\Controller {
 
       # attempt to remove the job ID
       try {
-        echo shell_exec("sudo -u \$USER atrm " . $pass->at_job_id . " 2>&1");
+        echo shell_exec("sudo -u smackay /usr/bin/atrm " . $pass->at_job_id . " 2>&1");
       } catch (exception $e) {
         error_log("Could not delete pass job ID using atrm for job ID: " . $pass->at_job_id . " - " . $e);
       }
@@ -61,33 +69,41 @@ class AdminController extends \Lib\Controller {
     }
 
     $pass->getActiveList();
-    $args = array_merge($args, array('pass' => $pass,
-                                     'status_msg' => $status_msg,
-                                     'admin_action' => 'passes'));
+    $args = array_merge($args, array(
+      'pass' => $pass,
+      'status_msg' => $status_msg,
+      'admin_action' => 'passes'
+    ));
     View::renderTemplate('Admin/passes.html', $args);
   }
 
-  public function capturesAction($args) {
+  public function capturesAction($args)
+  {
     $capture = $this->loadModel('Capture');
     $total_pages = $capture->totalPages(Config::ADMIN_CAPTURES_PER_PAGE);
 
     # pagination - and check for sanity
     $page_number = 1;
-    if (array_key_exists('page_no', $args) and $args['page_no'] > 0) $page_number = $args['page_no'];
-    if ($page_number > $total_pages) $page_number = $total_pages;
+    if (array_key_exists('page_no', $args) and $args['page_no'] > 0)
+      $page_number = $args['page_no'];
+    if ($page_number > $total_pages)
+      $page_number = $total_pages;
 
     $capture->getList($page_number, Config::ADMIN_CAPTURES_PER_PAGE);
-    $args = array_merge($args, array('capture' => $capture,
-                                     'cur_page' => $page_number,
-                                     'page_count' => $total_pages,
-                                     'admin_action' => 'captures'));
+    $args = array_merge($args, array(
+      'capture' => $capture,
+      'cur_page' => $page_number,
+      'page_count' => $total_pages,
+      'admin_action' => 'captures'
+    ));
 
     View::renderTemplate('Admin/captures.html', $args);
   }
 
   # TODO: This is not very DRY between this and the above function - do
   #       something about this in the future
-  public function deleteCaptureAction($args) {
+  public function deleteCaptureAction($args)
+  {
     $lang = include(__DIR__ . '/../Lang/' . Config::LANG . '.php');
     $capture = $this->loadModel('Capture');
     $pass = $this->loadModel('Pass');
@@ -105,13 +121,17 @@ class AdminController extends \Lib\Controller {
         $thumb = Config::THUMB_PATH . '/' . $capture->image_path . $enhancement;
 
         try {
-          if (file_exists($img)) { unlink($img); }
+          if (file_exists($img)) {
+            unlink($img);
+          }
         } catch (exception $e) {
           error_log("Could not delete file: " . $img . " - " . $e);
         }
 
         try {
-          if (file_exists($thumb)) { unlink($thumb); }
+          if (file_exists($thumb)) {
+            unlink($thumb);
+          }
         } catch (exception $e) {
           error_log("Could not delete file: " . $thumb . " - " . $e);
         }
@@ -130,18 +150,97 @@ class AdminController extends \Lib\Controller {
 
     # pagination - and check for sanity
     $page_number = 1;
-    if (array_key_exists('page_no', $args) and $args['page_no'] > 0) $page_number = $args['page_no'];
-    if ($page_number > $total_pages) $page_number = $total_pages;
+    if (array_key_exists('page_no', $args) and $args['page_no'] > 0)
+      $page_number = $args['page_no'];
+    if ($page_number > $total_pages)
+      $page_number = $total_pages;
 
     $capture->getList($page_number, Config::ADMIN_CAPTURES_PER_PAGE);
-    $args = array_merge($args, array('capture' => $capture,
-                                     'cur_page' => $page_number,
-                                     'page_count' => $total_pages,
-                                     'status_msg' => $status_msg,
-                                     'admin_action' => 'captures'));
+    $args = array_merge($args, array(
+      'capture' => $capture,
+      'cur_page' => $page_number,
+      'page_count' => $total_pages,
+      'status_msg' => $status_msg,
+      'admin_action' => 'captures'
+    ));
 
     View::renderTemplate('Admin/captures.html', $args);
   }
+
+    # TODO: This is not very DRY between this and the above function - do
+  #       something about this in the future
+  public function deleteMultiplePassAction($args)
+  {
+    $lang = include(__DIR__ . '/../Lang/' . Config::LANG . '.php');
+    $capture = $this->loadModel('Capture');
+    $pass = $this->loadModel('Pass');
+    # attempt to delete the user-specified capture
+    $status_msg = 'Fail';
+
+    if (array_key_exists('pass_ids', $args) and $args['pass_ids'] > 0) {
+      $passIds = $args['pass_ids'];
+      $arrPassIds = explode(',', $passIds);
+      foreach ($arrPassIds as $capture_id) {
+
+        $capture->getEnhancements($capture_id);
+        $capture->getImagePath($capture_id);
+
+        # delete images from disk
+        foreach ($capture->enhancements as $enhancement) {
+          $img = Config::IMAGE_PATH . '/' . $capture->image_path . $enhancement;
+          $thumb = Config::THUMB_PATH . '/' . $capture->image_path . $enhancement;
+
+          try {
+            if (file_exists($img)) {
+              unlink($img);
+            }
+          } catch (exception $e) {
+            error_log("Could not delete file: " . $img . " - " . $e);
+          }
+
+          try {
+            if (file_exists($thumb)) {
+              unlink($thumb);
+            }
+          } catch (exception $e) {
+            error_log("Could not delete file: " . $thumb . " - " . $e);
+          }
+        }
+
+        # remove capture and pass records from database
+        $capture->getStartEpoch($capture_id);
+        $capture->deleteById($capture_id);
+        $pass->deleteByPassStart($capture->start_epoch);
+        $status_msg = 'Success';
+      }
+    } else {
+      $status_msg = $lang['fail_delete_missing_id'];
+    }
+
+    $total_pages = $capture->totalPages(Config::ADMIN_CAPTURES_PER_PAGE);
+
+    # pagination - and check for sanity
+    $page_number = 1;
+    if (array_key_exists('page_no', $args) and $args['page_no'] > 0)
+      $page_number = $args['page_no'];
+    if ($page_number > $total_pages)
+      $page_number = $total_pages;
+
+    $capture->getList($page_number, Config::ADMIN_CAPTURES_PER_PAGE);
+    $args = array_merge($args, array(
+      'capture' => $capture,
+      'cur_page' => $page_number,
+      'page_count' => $total_pages,
+      'status_msg' => $status_msg,
+      'admin_action' => 'captures'
+    ));
+
+    View::renderTemplate('Admin/captures.html', $args);
+  }
+
 }
+
+
+
 
 ?>

--- a/webpanel/App/Lang/en.php
+++ b/webpanel/App/Lang/en.php
@@ -2,7 +2,10 @@
 return array(
   "admin" => "Admin",
   "admin_delete_confirm_header" => "Confirm Deletion",
-  "admin_capture_delete_warning" => "Click the dust bin next to the captures you want to delete to have both the pass/capture removed from the database and all associated images deleted. **WARNING**: This is irreversible, so please ensure this is what you want!",
+  "admin_delete_confirm_multiple_header" => "Confirm Multiple Deletion",
+  "admin_delete_multiple" => "Deletion Multiple",
+  "admin_select_deselect" => "Toggle Selection",
+  "admin_capture_delete_warning" => "Click the dust bin next to the captures you want to delete to have both the pass/capture removed from the database and all associated images deleted. To perform multiple delete, select the checkbox beside all captures you want to delete and click the 'Delete Multiple' button at bottom of page. **WARNING**: This is irreversible, so please ensure this is what you want!",
   "admin_pass_delete_warning" => "Click the dust bin next to the passes you want to delete to have the pass unscheduled and removed from the database. **WARNING**: This is irreversible, so please ensure this is what you want!",
   "cancel" => "Cancel",
   "captures" => "Captures",
@@ -29,7 +32,7 @@ return array(
   "prev" => "Prev",
   "running_pass" => "Capture in progress...",
   "satellite" => "Satellite",
-  "successful_delete_capture" => "Successfully deleted capture",
+  "successful_delete_capture" => "Successfully deleted capture(s)",
   "successful_delete_pass" => "Successfully deleted pass",
   "travel_direction" => "Direction",
 );

--- a/webpanel/App/Views/Admin/captures.html
+++ b/webpanel/App/Views/Admin/captures.html
@@ -1,122 +1,161 @@
 {% extends "base.html" %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" type="text/css" href="/assets/css/pagination.css">
-  <link rel="stylesheet" type="text/css" href="/assets/css/admin.css">
+<link rel="stylesheet" type="text/css" href="/assets/css/pagination.css">
+<link rel="stylesheet" type="text/css" href="/assets/css/admin.css">
 {% endblock %}
 
 {% block body %}
-  {% if status_msg is defined %}
-    {% if status_msg == 'Success' %}
-      <div class="alert alert-success alert-dismissible fade show" role="alert">
-        {{ lang['successful_delete_capture'] }}
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+{% if status_msg is defined %}
+{% if status_msg == 'Success' %}
+<div class="alert alert-success alert-dismissible fade show" role="alert">
+  {{ lang['successful_delete_capture'] }}
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+{% else %}
+<div class="alert alert-danger alert-dismissible fade show" role="alert">
+  {{ status_msg }}
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+{% endif %}
+{% endif %}
+
+{% include('Admin/nav.html') %}
+
+<p class="lead text-center">
+  {{ lang['admin_capture_delete_warning'] }}
+</p>
+
+<nav aria-label="page" id="pagination" class="mb-0">
+  {% include('Captures/pagination.html') %}
+</nav>
+
+<div class="page-count-summary mb-0 mx-2 my-1">
+  {{ "#{lang['page']} #{cur_page} #{lang['of']} #{page_count}" }}
+</div>
+
+<table class="table table-bordered" id="admin-capture-list">
+  <thead class="thead-light">
+    <tr>
+      <th scope="col" class="text-center">
+        <button type="button" id="toggleSelectButton" class="btn btn-sm btn-secondary" 
+  
+        data-target="#toggleSelect"><i class="fa">{{ lang['admin_select_deselect'] }}</i></button>
+
+      </th>
+      <th scope="col" class="text-center align-middle">{{ lang['select'] }}</th>
+      <th scope="col" class="text-center align-middle">{{ lang['satellite'] }}</th>
+      <th scope="col" class="text-center align-middle">{{ lang['pass_start'] }} / {{ lang['max_elev'] }}</th>
+      <th scope="col" class="text-center align-middle">{{ lang['image'] }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for capture in capture.list %}
+    <tr scope="row">
+      <td>
+        <input type="checkbox" id="{{ capture.id }}" sat-name="{{ capture.sat_name }}" 
+        elevation="{{ capture.max_elev }}"
+          pass-start="{{ capture.pass_start|date(constant('Config\\Config::DATETIME_FORMAT')) }}"
+        >
+      </td>
+      <td class="capture-select text-center align-middle">
+        <button type="button" class="btn btn-sm btn-danger delete-capture" data-toggle="modal"
+          data-capture-id="{{ capture.id }}" data-sat-name="{{ capture.sat_name }}"
+          data-elevation="{{ capture.max_elev }}"
+          data-pass-start="{{ capture.pass_start|date(constant('Config\\Config::DATETIME_FORMAT')) }}"
+          data-target="#confirmDeleteCapture"><i class="fa fa-trash"></i></button>
+      </td>
+      <td class="capture-sat-name text-center align-middle">{{ capture.sat_name }}</td>
+      <td class="capture-pass-start-elev text-center align-middle">
+        {{ capture.pass_start|date(constant('Config\\Config::DATETIME_FORMAT')) }} @
+        {{ capture.max_elev }}&#176;
+      </td>
+      <td class="capture-thumbnail text-center align-middle">
+        <a href="/captures/listImages?pass_id={{ capture.id }}">
+          {% if capture.sat_type == 0 %}
+          {% if capture.daylight_pass == 1 %}
+          <img class="card-img-top"
+            src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-website-thumbnail.jpg">
+          {% else %}
+          <img class="card-img-top"
+            src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-website-thumbnail.jpg">
+          {% endif %}
+          {% elseif capture.sat_type == 1 %}
+          {% if capture.daylight_pass == 1 %}
+          <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-MSA.jpg">
+          {% else %}
+          <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-MCIR.jpg">
+          {% endif %}
+          {% elseif capture.sat_type == 2 %}
+          <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-0.jpg">
+          {% endif %}
+        </a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<button type="button" id="multipleDeleteButton" class="btn btn-sm btn-danger delete-capture" data-toggle="modal"
+  
+  data-target="#confirmDeleteMultiple"><i class="fa fa-trash"></i>{{ lang['admin_delete_multiple'] }}</button>
+<nav aria-label="page" id="pagination" class="d-md-none mb-0">
+  {% include('Captures/pagination.html') %}
+</nav>
+
+<div class="modal fade" id="confirmDeleteCapture" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteLabel"
+  aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirmDeleteLabel">{{ lang['admin_delete_confirm_header'] }}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-    {% else %}
-      <div class="alert alert-danger alert-dismissible fade show" role="alert">
-        {{ status_msg }}
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+      <div class="modal-body">
+        <p id="contents">
+          <strong>{{ lang.satellite }}: </strong><span id="satellite-name"></span><br>
+          <strong>{{ lang.pass_start }}: </strong><span id="pass-start"></span><br>
+          <strong>{{ lang.elev }}: </strong><span id="capture-elevation"></span>&#176;<br>
+        </p>
       </div>
-    {% endif %}
-  {% endif %}
-
-  {% include('Admin/nav.html') %}
-
-  <p class="lead text-center">
-    {{ lang['admin_capture_delete_warning'] }}
-  </p>
-
-  <nav aria-label="page" id="pagination" class="mb-0">
-    {% include('Captures/pagination.html') %}
-  </nav>
-
-  <div class="page-count-summary mb-0 mx-2 my-1">
-    {{ "#{lang['page']} #{cur_page} #{lang['of']} #{page_count}" }}
-  </div>
-
-  <table class="table table-bordered" id="admin-capture-list">
-    <thead class="thead-light">
-      <tr>
-        <th scope="col" class="text-center"></th>
-        <th scope="col" class="text-center align-middle">{{ lang['satellite'] }}</th>
-        <th scope="col" class="text-center align-middle">{{ lang['pass_start'] }} / {{ lang['max_elev'] }}</th>
-        <th scope="col" class="text-center align-middle">{{ lang['image'] }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for capture in capture.list %}
-        <tr scope="row">
-          <td class="capture-select text-center align-middle">
-            <button type="button" class="btn btn-sm btn-danger delete-capture" data-toggle="modal"
-                                 data-capture-id="{{ capture.id }}"
-                                 data-sat-name="{{ capture.sat_name }}"
-                                 data-elevation="{{ capture.max_elev }}"
-                                 data-pass-start="{{ capture.pass_start|date(constant('Config\\Config::DATETIME_FORMAT')) }}"
-                                 data-target="#confirmDeleteCapture"><i class="fa fa-trash"></i></button>
-          </td>
-          <td class="capture-sat-name text-center align-middle">{{ capture.sat_name }}</td>
-          <td class="capture-pass-start-elev text-center align-middle">
-            {{ capture.pass_start|date(constant('Config\\Config::DATETIME_FORMAT')) }} @
-            {{ capture.max_elev }}&#176;
-          </td>
-          <td class="capture-thumbnail text-center align-middle">
-            <a href="/captures/listImages?pass_id={{ capture.id }}">
-              {% if capture.sat_type == 0 %}
-               {% if capture.daylight_pass == 1 %}
-                 <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-website-thumbnail.jpg">
-               {% else %}
-                 <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-website-thumbnail.jpg">
-               {% endif %}
-               {% elseif capture.sat_type == 1 %}
-                 {% if capture.daylight_pass == 1 %}
-                 <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-MSA.jpg">
-               {% else %}
-                 <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-MCIR.jpg">
-               {% endif %}
-               {% elseif capture.sat_type == 2 %}
-                 <img class="card-img-top" src="{{ constant('Config\\Config::THUMB_PATH') }}/{{ capture.file_path }}-0.jpg">
-              {% endif %}
-            </a>
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-
-  <nav aria-label="page" id="pagination" class="d-md-none mb-0">
-    {% include('Captures/pagination.html') %}
-  </nav>
-
-  <div class="modal fade" id="confirmDeleteCapture" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="confirmDeleteLabel">{{ lang['admin_delete_confirm_header'] }}</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <p id="contents">
-            <strong>{{ lang.satellite }}: </strong><span id="satellite-name"></span><br>
-            <strong>{{ lang.pass_start }}: </strong><span id="pass-start"></span><br>
-            <strong>{{ lang.elev }}: </strong><span id="capture-elevation"></span>&#176;<br>
-          </p>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ lang['cancel'] }}</button>
-          <a href="" id="confirmDeletion" type="button" class="btn btn-danger">{{ lang['confirm'] }}</a>
-        </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ lang['cancel'] }}</button>
+        <a href="" id="confirmDeletion" type="button" class="btn btn-danger">{{ lang['confirm'] }}</a>
       </div>
     </div>
   </div>
+</div>
+
+<div class="modal fade" id="confirmDeleteMultiple" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteLabel"
+  aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirmDeleteLabel">{{ lang['admin_delete_confirm_multiple_header'] }}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p id="contents">
+          <span id="satellite-name"></span><br>
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ lang['cancel'] }}</button>
+        <a href="" id="confirmDeletion" type="button" class="btn btn-danger">{{ lang['confirm'] }}</a>
+      </div>
+    </div>
+  </div>
+</div>
 
 {% endblock %}
 
 {% block js_includes %}
-  <script src="/assets/js/admin.js"></script>
+<script src="/assets/js/admin.js"></script>
 {% endblock %}

--- a/webpanel/public/assets/js/admin.js
+++ b/webpanel/public/assets/js/admin.js
@@ -31,3 +31,57 @@ $('#confirmDeleteCapture').on('show.bs.modal', function (event) {
   modal.find('.modal-body p#contents span#capture-elevation').html(elevation);
   modal.find('.modal-footer a#confirmDeletion').attr('href', '/admin/deleteCapture?id=' + capture_id);
 });
+
+
+$('#confirmDeleteMultiple').on('show.bs.modal', function (event) {
+  var ids = [];
+  var info = [];
+  $('input[type=checkbox]:checked').each(function () {
+    var id = $(this).attr("id");
+    var satellite_name = $(this).attr("sat-name");
+    var elevation = $(this).attr('elevation');
+    var pass_start = $(this).attr('pass-start');
+    ids.push(id);
+    info.push("<p>" + satellite_name + " " + pass_start + "</p>");
+
+  });
+  // get data population
+  var capture_ids = ids.join([separator = ',']);
+
+  // draw modal and assign vars
+  var modal = $(this);
+  modal.find('.modal-body p#contents span#satellite-name').html(info);
+  modal.find('.modal-footer a#confirmDeletion').attr('href', '/admin/deleteMultiplePass?pass_ids=' + capture_ids);
+});
+
+// Event to check if anything selected for Deletion and show or hide button
+$(":checkbox").change(function () {
+  SetMultipleDeleteButton();
+});
+
+// Hide the Multiple Delete button on first load
+$( document ).ready(function() {
+  $("#multipleDeleteButton").hide();
+});
+
+// Event to toggle check boxes for each row
+$("#toggleSelectButton").click(function () {
+  $('input[type=checkbox]').each(function () {
+    this.checked = !this.checked;
+  });
+  SetMultipleDeleteButton();
+});
+
+// common function to set the Multiple Delete button show or hide
+function SetMultipleDeleteButton() {
+  var itemsSelected = false;
+  $('input[type=checkbox]:checked').each(function () {
+    itemsSelected = true;
+  });
+  if (itemsSelected) {
+    $("#multipleDeleteButton").show();
+  }
+  else {
+    $("#multipleDeleteButton").hide();
+  }
+}


### PR DESCRIPTION
Hi, 
This pull request adds the functionality to perform multiple delete on the Admin/Capture page. 
Relates to the issue  [https://github.com/jekhokie/raspberry-noaa-v2/issues/447](url)

This is done by adding a checkbox next to each capture. When one or more captures are selected, a button is visible at the bottom of the page, which when clicked provides a summary dialog of the captures to be deleted. From that model box, the user can confirm the deletion and the system will delete the selected captures.

Additionally, in the table with the passes, the header for the checkbox has an option to toggle the selected checkboxes, allowing for ease of selecting all captures and then un checking the ones which should not be deleted.

I have made changes to the en.php, for some text which is shown in the screens, but I do not have the ability to translate into the other languages, so this would need to be done by someone who is familiar with those languages.

Apologies, but my editor seems to have formatted some of the files in a different style than the original.

I have followed the style as used for single delete. 

Let me know if you have any questions.
